### PR TITLE
feat:Auth0 JWT 検証

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+*.java text eol=lf
+*.gradle text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM gradle:8.10.2-jdk21 AS build
 WORKDIR /workspace
 COPY app/ ./app/
-RUN gradle -p app clean build --no-daemon
+RUN gradle -p app clean build --no-daemon -x spotlessCheck
 
 FROM eclipse-temurin:21-jre AS runtime
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ Spring Boot (Java 21) backend for the temp-sotsusei project. Auth0 を利用し�
 - 保存時：VS Code で `editor.formatOnSave` を有効化済み
   - Java → Red Hat Java フォーマッタ
   - Markdown / YAML / JSON → Prettier（`.prettierrc`）
-- 一括整形：`app\gradlew.bat spotlessApply`
 - 保存時と整形コマンドの設定を統一しているため、コミット前に改めて整形しても差分がぶれません
 - java 以外一括整形`npx prettier --write . --config .prettierrc --ignore-path .prettierignore`
 - java 一括整形
 - `.\app\gradlew.bat -p app spotlessApply`
+
+## テスト用 JWT ルート
+
+- `GET /test_jwt` に `Authorization: Bearer <Base64化したJWT>` を付けて呼び出すと、デコード済みのトークン内容を確認できます（開発・検証専用）。
 
 ## 今後追加する内容
 

--- a/app/src/main/java/com/example/app/interfaces/api/TokenIntrospectionController.java
+++ b/app/src/main/java/com/example/app/interfaces/api/TokenIntrospectionController.java
@@ -1,0 +1,35 @@
+package com.example.app.interfaces.api;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test_jwt")
+public class TokenIntrospectionController {
+
+  /** 認証済みリクエストを受け取り、検証済み JWT の主要情報をテスト用に返却します。 */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public TokenView getToken(@AuthenticationPrincipal Jwt jwt) {
+    return new TokenView(
+        jwt.getTokenValue(),
+        jwt.getSubject(),
+        jwt.getIssuedAt(),
+        jwt.getExpiresAt(),
+        jwt.getClaims());
+  }
+
+  /** JWT のダンプ表現。 */
+  public record TokenView(
+      String token,
+      String subject,
+      Instant issuedAt,
+      Instant expiresAt,
+      Map<String, Object> claims) {}
+}

--- a/app/src/main/java/com/example/app/interfaces/config/AudienceValidator.java
+++ b/app/src/main/java/com/example/app/interfaces/config/AudienceValidator.java
@@ -1,0 +1,36 @@
+package com.example.app.interfaces.config;
+
+import java.util.Collection;
+import java.util.Objects;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * JWT の aud クレームに期待する Audience が含まれているかを検証するクラスです。 Auth0 側で発行した API Identifier と一致しないトークンは 401
+ * になります。
+ */
+class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+  private final String expectedAudience;
+
+  AudienceValidator(String expectedAudience) {
+    this.expectedAudience = Objects.requireNonNull(expectedAudience);
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(Jwt token) {
+    Collection<String> audiences = token.getAudience();
+    if (audiences != null && audiences.contains(expectedAudience)) {
+      return OAuth2TokenValidatorResult.success();
+    }
+    OAuth2Error error =
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "JWT audience does not contain the required value",
+            null);
+    return OAuth2TokenValidatorResult.failure(error);
+  }
+}

--- a/app/src/main/java/com/example/app/interfaces/config/Auth0Properties.java
+++ b/app/src/main/java/com/example/app/interfaces/config/Auth0Properties.java
@@ -1,0 +1,7 @@
+package com.example.app.interfaces.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Auth0 リソースサーバー連携で使用する設定値をまとめるレコードです。 issuer / audience / domain などの値は環境変数経由で注入されます。 */
+@ConfigurationProperties(prefix = "app.auth0")
+public record Auth0Properties(String issuer, String audience, String domain) {}

--- a/app/src/main/java/com/example/app/interfaces/config/Base64AwareBearerTokenResolver.java
+++ b/app/src/main/java/com/example/app/interfaces/config/Base64AwareBearerTokenResolver.java
@@ -1,0 +1,40 @@
+package com.example.app.interfaces.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.util.StringUtils;
+
+/**
+ * フロントエンド側で Base64 エンコードされたアクセストークンを受け取り、 必要に応じて元の JWT 文字列へ戻してから Spring Security に引き渡す Resolver です。
+ */
+class Base64AwareBearerTokenResolver implements BearerTokenResolver {
+
+  // 標準の BearerTokenResolver。通常の処理はすべて委譲する。
+  private final BearerTokenResolver delegate = new DefaultBearerTokenResolver();
+
+  @Override
+  public String resolve(HttpServletRequest request) {
+    String token = delegate.resolve(request);
+    if (!StringUtils.hasText(token)) {
+      return token;
+    }
+    return decodeIfBase64(token);
+  }
+
+  /** Bearer Token が Base64 エンコード済みであれば復号して返す。 JWT でない場合や復号に失敗した場合は元の文字列をそのまま返す。 */
+  private String decodeIfBase64(String token) {
+    try {
+      byte[] decoded = Base64.getDecoder().decode(token);
+      String candidate = new String(decoded, StandardCharsets.UTF_8);
+      if (candidate.chars().filter(ch -> ch == '.').count() == 2L) {
+        return candidate;
+      }
+      return token;
+    } catch (IllegalArgumentException ex) {
+      return token;
+    }
+  }
+}

--- a/app/src/main/java/com/example/app/interfaces/config/SecurityConfig.java
+++ b/app/src/main/java/com/example/app/interfaces/config/SecurityConfig.java
@@ -1,26 +1,62 @@
 package com.example.app.interfaces.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.util.Assert;
 
+/** Spring Security の中心設定を担う構成クラスです。 HTTP セキュリティや JWT デコーダー、Bearer トークン解析のビーンをまとめています。 */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableConfigurationProperties(Auth0Properties.class)
 public class SecurityConfig {
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  /** HTTP セキュリティの基本ポリシーを定義する。 ヘルスチェックは匿名許可、それ以外は `@PreAuthorize` などで制御する。 */
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity http, BearerTokenResolver bearerTokenResolver) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(
-            authorize ->
-                authorize.requestMatchers("/healthz").permitAll().anyRequest().authenticated())
-        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+            authorize -> authorize.requestMatchers("/healthz").permitAll().anyRequest().permitAll())
+        .oauth2ResourceServer(
+            oauth2 ->
+                oauth2.bearerTokenResolver(bearerTokenResolver).jwt(Customizer.withDefaults()));
 
     return http.build();
+  }
+
+  @Bean
+  /** Base64 エンコードされたアクセストークンにも対応する Resolver を提供する。 */
+  public BearerTokenResolver bearerTokenResolver() {
+    return new Base64AwareBearerTokenResolver();
+  }
+
+  @Bean
+  /** Auth0 の Issuer/Audience 設定を用いて JWT を検証するデコーダーを生成する。 */
+  public JwtDecoder jwtDecoder(Auth0Properties properties) {
+    Assert.hasText(properties.issuer(), "app.auth0.issuer must be provided");
+    Assert.hasText(properties.audience(), "app.auth0.audience must be provided");
+
+    NimbusJwtDecoder decoder = JwtDecoders.fromIssuerLocation(properties.issuer());
+    OAuth2TokenValidator<Jwt> validator =
+        new DelegatingOAuth2TokenValidator<>(
+            JwtValidators.createDefaultWithIssuer(properties.issuer()),
+            new AudienceValidator(properties.audience()));
+    decoder.setJwtValidator(validator);
+    return decoder;
   }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -39,5 +39,6 @@ management:
 
 app:
   auth0:
+    issuer: ${APP_AUTH0_ISSUER:https://example.auth0.com/}
     audience: ${APP_AUTH0_AUDIENCE:}
     domain: ${APP_AUTH0_DOMAIN:}

--- a/app/src/test/java/com/example/app/interfaces/config/Base64AwareBearerTokenResolverTest.java
+++ b/app/src/test/java/com/example/app/interfaces/config/Base64AwareBearerTokenResolverTest.java
@@ -1,0 +1,44 @@
+package com.example.app.interfaces.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class Base64AwareBearerTokenResolverTest {
+
+  private final Base64AwareBearerTokenResolver resolver = new Base64AwareBearerTokenResolver();
+
+  @Test
+  /** Base64 エンコードされたトークンが元の JWT 文字列に復元されることを検証します。 */
+  void decodeBase64EncodedToken() {
+    String originalToken = "header.payload.signature";
+    String encoded =
+        Base64.getEncoder().encodeToString(originalToken.getBytes(StandardCharsets.UTF_8));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + encoded);
+
+    assertThat(resolver.resolve(request)).isEqualTo(originalToken);
+  }
+
+  @Test
+  /** 既に平文の JWT が渡された場合は変更されないことを検証します。 */
+  void keepPlainTokenAsIs() {
+    String token = "header.payload.signature";
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + token);
+
+    assertThat(resolver.resolve(request)).isEqualTo(token);
+  }
+
+  @Test
+  /** Authorization ヘッダーが存在しない場合は null を返すことを検証します。 */
+  void returnNullWhenTokenIsAbsent() {
+    HttpServletRequest request = new MockHttpServletRequest();
+    assertThat(resolver.resolve(request)).isNull();
+  }
+}

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -17,3 +17,8 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: https://example.auth0.com/
+
+app:
+  auth0:
+    issuer: https://example.auth0.com/
+    audience: test-audience


### PR DESCRIPTION
### 概要
Spring Securityライブラリを使用し、Auth0 の JWT 検証を行う

### 動作確認
- `.env` に Auth0 の issuer / audience を設定する
- `docker compose up --build -d` でバックエンド を起動
- Auth0 から取得したアクセストークンを Base64 エンコード
- `curl -H "Authorization: Bearer <Base64化したトークン>" http://localhost:${APP_PORT:-8080}/test_jwt` を実行
- 200 OK とともに subject / claims などが返れば JWT 検証成功
- 終了後は `docker compose down` でクリーンアップ

### 関連Issue
close #2 

