### PR TITLE
feat:thumbnailsテーブルの実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+    implementation 'com.github.f4b6a3:uuid-creator:6.1.1'
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnail/ThumbnailService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnail/ThumbnailService.java
@@ -1,0 +1,95 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnail;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** サムネイル周辺のユースケースを取りまとめるアプリケーションサービス。 */
+@Service
+public class ThumbnailService {
+
+  /** 永続化処理を委譲するサムネイルリポジトリ。 */
+  private final ThumbnailRepository thumbnailRepository;
+
+  /** 時系列ソート可能な UUID を生成する内部サービス。 */
+  private final UuidGeneratorService uuidGeneratorService;
+
+  /**
+   * DI により依存を受け取り、サービス層の処理に活用する。
+   *
+   * @param thumbnailRepository サムネイルリポジトリ
+   * @param uuidGeneratorService UUID 生成サービス
+   */
+  public ThumbnailService(
+      ThumbnailRepository thumbnailRepository, UuidGeneratorService uuidGeneratorService) {
+    this.thumbnailRepository = thumbnailRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+  }
+
+  /**
+   * すべてのサムネイルを取得する。
+   *
+   * @return サムネイル一覧
+   */
+  public List<Thumbnail> findAll() {
+    return thumbnailRepository.findAll();
+  }
+
+  /**
+   * サムネイルを ID 指定で取得する。
+   *
+   * @param thumbnailId サムネイル ID
+   * @return 見つかったサムネイル（存在しない場合は空）
+   */
+  public Optional<Thumbnail> findById(String thumbnailId) {
+    return thumbnailRepository.findById(thumbnailId);
+  }
+
+  /**
+   * サムネイルを新規作成する。
+   *
+   * @param thumbnailPath 保存するファイルパス
+   * @return 作成されたサムネイル
+   */
+  @Transactional
+  public Thumbnail create(String thumbnailPath) {
+    Instant now = Instant.now();
+    // UUID v7 を利用して時系列順に並べられる ID を採番する
+    String thumbnailId = uuidGeneratorService.generateV7();
+    Thumbnail thumbnail = new Thumbnail(thumbnailId, thumbnailPath, now, now);
+    return thumbnailRepository.save(thumbnail);
+  }
+
+  /**
+   * 既存サムネイルのパスを更新する。
+   *
+   * @param thumbnailId サムネイル ID
+   * @param thumbnailPath 更新後のパス
+   * @return 更新後のサムネイル（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<Thumbnail> update(String thumbnailId, String thumbnailPath) {
+    return thumbnailRepository
+        .findById(thumbnailId)
+        // createdAt は維持しつつ、新しいパスと更新日時を反映させる
+        .map(
+            existing ->
+                new Thumbnail(thumbnailId, thumbnailPath, existing.createdAt(), Instant.now()))
+        .map(thumbnailRepository::save);
+  }
+
+  /**
+   * サムネイルを削除する。
+   *
+   * @param thumbnailId サムネイル ID
+   */
+  @Transactional
+  public void delete(String thumbnailId) {
+    thumbnailRepository.deleteById(thumbnailId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/uuid/UuidGeneratorService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/uuid/UuidGeneratorService.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.application.uuid;
+
+/**
+ * UUID を生成するための内部サービス。
+ *
+ * <p>時系列ソートに適した UUID v7 を提供する。
+ */
+public interface UuidGeneratorService {
+
+  /**
+   * UUID v7 をテキスト表現で返す。
+   *
+   * @return UUID v7 文字列
+   */
+  String generateV7();
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/uuid/UuidGeneratorServiceImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/uuid/UuidGeneratorServiceImpl.java
@@ -1,0 +1,23 @@
+package io.github.tempsotsusei.kotobanotane.application.uuid;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+import org.springframework.stereotype.Component;
+
+/**
+ * UuidGeneratorService の実装クラス。
+ *
+ * <p>uuid-creator ライブラリを利用して UUID v7 を生成する。
+ */
+@Component
+public class UuidGeneratorServiceImpl implements UuidGeneratorService {
+
+  /**
+   * 時系列ソート可能な UUID v7 を生成する。
+   *
+   * @return UUID v7 を表す文字列
+   */
+  @Override
+  public String generateV7() {
+    return UuidCreator.getTimeOrderedEpoch().toString();
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/Thumbnail.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/Thumbnail.java
@@ -1,0 +1,11 @@
+package io.github.tempsotsusei.kotobanotane.domain.thumbnail;
+
+import java.time.Instant;
+
+/**
+ * サムネイル情報を表現するドメインレコード。
+ *
+ * <p>アプリケーション層や永続化層へ値を受け渡すためのシンプルなコンテナとして利用する。
+ */
+public record Thumbnail(
+    String thumbnailId, String thumbnailPath, Instant createdAt, Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/ThumbnailRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/ThumbnailRepository.java
@@ -1,0 +1,42 @@
+package io.github.tempsotsusei.kotobanotane.domain.thumbnail;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * サムネイル永続化に関する操作を集約するリポジトリインターフェース。
+ *
+ * <p>実装はインフラ層に委ね、ドメイン層からは抽象化された操作のみを利用する。
+ */
+public interface ThumbnailRepository {
+
+  /**
+   * サムネイルを識別子で検索する。
+   *
+   * @param thumbnailId サムネイル ID
+   * @return 該当レコード（存在しない場合は空）
+   */
+  Optional<Thumbnail> findById(String thumbnailId);
+
+  /**
+   * 登録されているサムネイルをすべて取得する。
+   *
+   * @return サムネイルの一覧
+   */
+  List<Thumbnail> findAll();
+
+  /**
+   * サムネイルを新規作成または更新する。
+   *
+   * @param thumbnail 保存対象のドメインモデル
+   * @return 保存後の状態
+   */
+  Thumbnail save(Thumbnail thumbnail);
+
+  /**
+   * サムネイルを識別子で削除する。
+   *
+   * @param thumbnailId サムネイル ID
+   */
+  void deleteById(String thumbnailId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailEntity.java
@@ -1,0 +1,68 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** thumbnails テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "thumbnails")
+public class ThumbnailEntity {
+
+  /** サムネイルを一意に識別するカラム。 */
+  @Id
+  @Column(name = "thumbnail_id", length = 255, nullable = false)
+  private String thumbnailId;
+
+  /** 画像ファイルの保存先パス。 */
+  @Column(name = "thumbnail_path", length = 255, nullable = false)
+  private String thumbnailPath;
+
+  /** レコード作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  /** レコード更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  /** JPA がリフレクションで利用するためのデフォルトコンストラクタ。 */
+  protected ThumbnailEntity() {}
+
+  public ThumbnailEntity(
+      String thumbnailId, String thumbnailPath, Instant createdAt, Instant updatedAt) {
+    this.thumbnailId = thumbnailId;
+    this.thumbnailPath = thumbnailPath;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getThumbnailId() {
+    return thumbnailId;
+  }
+
+  public String getThumbnailPath() {
+    return thumbnailPath;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
+   * サムネイルパスと更新日時を変更する。
+   *
+   * @param newPath 変更後のパス
+   * @param newUpdatedAt 変更後の更新日時
+   */
+  public void updatePath(String newPath, Instant newUpdatedAt) {
+    this.thumbnailPath = newPath;
+    this.updatedAt = newUpdatedAt;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailJpaRepository.java
@@ -1,0 +1,6 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Spring Data JPA を利用したサムネイル向けの基本 CRUD リポジトリ。 */
+public interface ThumbnailJpaRepository extends JpaRepository<ThumbnailEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailMapper.java
@@ -1,0 +1,59 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.time.Instant;
+
+/**
+ * サムネイルのドメインモデルと JPA エンティティを相互変換するユーティリティ。
+ *
+ * <p>変換ロジックを 1 箇所に集約し、実装の重複や取り違えを防止するためのクラス。
+ */
+public final class ThumbnailMapper {
+
+  /** インスタンス化を禁止するためのプライベートコンストラクタ。 */
+  private ThumbnailMapper() {}
+
+  /**
+   * エンティティからドメインモデルへ変換する。
+   *
+   * @param entity 永続化層のエンティティ
+   * @return ドメイン層で利用するレコード
+   */
+  public static Thumbnail toDomain(ThumbnailEntity entity) {
+    return new Thumbnail(
+        entity.getThumbnailId(),
+        entity.getThumbnailPath(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  /**
+   * ドメインモデルからエンティティを生成する。
+   *
+   * @param thumbnail ドメインレコード
+   * @return JPA に保存可能なエンティティ
+   */
+  public static ThumbnailEntity toEntity(Thumbnail thumbnail) {
+    return new ThumbnailEntity(
+        thumbnail.thumbnailId(),
+        thumbnail.thumbnailPath(),
+        thumbnail.createdAt(),
+        thumbnail.updatedAt());
+  }
+
+  /**
+   * 既存エンティティを更新用に変換する。
+   *
+   * <p>mutable なエンティティの状態を書き換えたうえで、そのまま永続化処理へ渡す。
+   *
+   * @param entity 更新対象のエンティティ
+   * @param newThumbnailPath 新しいパス
+   * @param updatedAt 更新日時
+   * @return 更新後のエンティティ
+   */
+  public static ThumbnailEntity toEntityForUpdate(
+      ThumbnailEntity entity, String newThumbnailPath, Instant updatedAt) {
+    entity.updatePath(newThumbnailPath, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailRepositoryImpl.java
@@ -1,0 +1,61 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** ThumbnailRepository を Spring Data JPA で実装したクラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class ThumbnailRepositoryImpl implements ThumbnailRepository {
+
+  private final ThumbnailJpaRepository thumbnailJpaRepository;
+
+  public ThumbnailRepositoryImpl(ThumbnailJpaRepository thumbnailJpaRepository) {
+    this.thumbnailJpaRepository = thumbnailJpaRepository;
+  }
+
+  /** ID 指定でサムネイルを検索する。 */
+  @Override
+  public Optional<Thumbnail> findById(String thumbnailId) {
+    return thumbnailJpaRepository.findById(thumbnailId).map(ThumbnailMapper::toDomain);
+  }
+
+  /** テーブル内のサムネイルをすべて読み出す。 */
+  @Override
+  public List<Thumbnail> findAll() {
+    return thumbnailJpaRepository.findAll().stream().map(ThumbnailMapper::toDomain).toList();
+  }
+
+  /**
+   * サムネイルを永続化する。
+   *
+   * <p>既存レコードがあれば値を更新し、存在しなければ新規作成する。
+   */
+  @Override
+  @Transactional
+  public Thumbnail save(Thumbnail thumbnail) {
+    ThumbnailEntity entity =
+        thumbnailJpaRepository
+            .findById(thumbnail.thumbnailId())
+            .map(
+                existing ->
+                    ThumbnailMapper.toEntityForUpdate(
+                        existing, thumbnail.thumbnailPath(), thumbnail.updatedAt()))
+            .orElse(ThumbnailMapper.toEntity(thumbnail));
+
+    // JPA リポジトリで保存し、ドメインモデルへ変換して返却する
+    ThumbnailEntity saved = thumbnailJpaRepository.save(entity);
+    return ThumbnailMapper.toDomain(saved);
+  }
+
+  /** サムネイルを識別子で削除する。 */
+  @Override
+  @Transactional
+  public void deleteById(String thumbnailId) {
+    thumbnailJpaRepository.deleteById(thumbnailId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailCrudController.java
@@ -1,0 +1,107 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * サムネイル用の開発向け CRUD API を提供するコントローラ。
+ *
+ * <p>ユーザー CRUD と同じルーティング規約で統一し、動作確認を容易にする目的で設置する。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevThumbnailCrudController {
+
+  /** サムネイル関連処理を担うサービス。 */
+  private final ThumbnailService thumbnailService;
+
+  /** DI されたサービスを利用して処理を実行する。 */
+  public DevThumbnailCrudController(ThumbnailService thumbnailService) {
+    this.thumbnailService = thumbnailService;
+  }
+
+  /** サムネイルを全件取得する。 */
+  @GetMapping("/thumbnails")
+  @PreAuthorize("permitAll()")
+  public List<ThumbnailResponse> list() {
+    return thumbnailService.findAll().stream().map(ThumbnailResponse::from).toList();
+  }
+
+  /** サムネイルを 1 件取得する。 */
+  @GetMapping("/thumbnail/{thumbnailId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailResponse> get(@PathVariable String thumbnailId) {
+    return thumbnailService
+        .findById(thumbnailId)
+        .map(ThumbnailResponse::from)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** サムネイルを新規登録する。 */
+  @PostMapping("/thumbnail")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailResponse> create(@Valid @RequestBody ThumbnailRequest request) {
+    Thumbnail created = thumbnailService.create(request.thumbnailPath());
+    // 作成結果を 201 応答で返却し、クライアントに新規登録が成功したことを伝える
+    return ResponseEntity.status(HttpStatus.CREATED).body(ThumbnailResponse.from(created));
+  }
+
+  /** 既存サムネイルを更新する。 */
+  @PutMapping("/thumbnail/{thumbnailId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailResponse> update(
+      @PathVariable String thumbnailId, @Valid @RequestBody ThumbnailRequest request) {
+    return thumbnailService
+        .update(thumbnailId, request.thumbnailPath())
+        .map(ThumbnailResponse::from)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** サムネイルを削除する。 */
+  @DeleteMapping("/thumbnail/{thumbnailId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String thumbnailId) {
+    thumbnailService.delete(thumbnailId);
+    // 削除成功時はコンテンツ無しレスポンスを返す
+    return ResponseEntity.noContent().build();
+  }
+
+  /** サムネイルの作成・更新で利用するリクエストボディ。 */
+  public record ThumbnailRequest(@NotBlank @Size(max = 255) String thumbnailPath) {}
+
+  /** レスポンスとして返却する DTO。 */
+  public record ThumbnailResponse(
+      String thumbnailId, String thumbnailPath, Instant createdAt, Instant updatedAt) {
+
+    /** ドメインモデルからレスポンスを生成する。 */
+    static ThumbnailResponse from(Thumbnail thumbnail) {
+      return new ThumbnailResponse(
+          thumbnail.thumbnailId(),
+          thumbnail.thumbnailPath(),
+          thumbnail.createdAt(),
+          thumbnail.updatedAt());
+    }
+  }
+}

--- a/app/src/main/resources/db/migration/V2__create_thumbnails.sql
+++ b/app/src/main/resources/db/migration/V2__create_thumbnails.sql
@@ -1,0 +1,22 @@
+-- サムネイル情報を保持するテーブルを作成するマイグレーション
+CREATE TABLE IF NOT EXISTS thumbnails (
+    thumbnail_id VARCHAR(255) PRIMARY KEY,
+    thumbnail_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ
+);
+
+-- 更新時に updated_at を自動で書き換えるトリガー用関数
+CREATE OR REPLACE FUNCTION set_thumbnails_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 既存トリガーを削除してから再作成し、関数を紐付ける
+DROP TRIGGER IF EXISTS trg_thumbnails_updated_at ON thumbnails;
+CREATE TRIGGER trg_thumbnails_updated_at
+    BEFORE UPDATE ON thumbnails
+    FOR EACH ROW EXECUTE FUNCTION set_thumbnails_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailCrudControllerTest.java
@@ -1,0 +1,84 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * DevThumbnailCrudController の CRUD 動作を一巡させて検証する統合テスト。
+ *
+ * <p>開発用エンドポイントが期待どおりに動作するかを確認する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevThumbnailCrudControllerTest {
+
+  /** 開発用 API を呼び出すためのモック MVC。 */
+  @Autowired private MockMvc mockMvc;
+
+  /** JSON 変換に利用する ObjectMapper。 */
+  @Autowired private ObjectMapper objectMapper;
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    String initialPath = "/path/to/thumbnail.png";
+    String updatedPath = "/path/to/updated-thumbnail.png";
+
+    // --- Create: 新規作成してレスポンスから ID を取得 ---
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/thumbnail")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(Map.of("thumbnailPath", initialPath))))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.thumbnailPath").value(initialPath))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String thumbnailId = created.get("thumbnailId").toString();
+
+    // --- Read (list): 一覧取得で登録済みデータが存在することを検証 ---
+    mockMvc
+        .perform(get("/api/crud/thumbnails"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].thumbnailId").exists());
+
+    // --- Read (single): 個別取得で最初に作成したパスが返ることを確認 ---
+    mockMvc
+        .perform(get("/api/crud/thumbnail/" + thumbnailId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.thumbnailPath").value(initialPath));
+
+    // --- Update: パスを更新して変更が反映されることを確認 ---
+    mockMvc
+        .perform(
+            put("/api/crud/thumbnail/" + thumbnailId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("thumbnailPath", updatedPath))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.thumbnailPath").value(updatedPath));
+
+    // --- Delete: 削除 API を呼び、204 応答を確認 ---
+    mockMvc.perform(delete("/api/crud/thumbnail/" + thumbnailId)).andExpect(status().isNoContent());
+  }
+}


### PR DESCRIPTION
### 概要
thumbnailsテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Thumbnail CRUD API テスト
- 開発プロファイル (`SPRING_PROFILES_ACTIVE=dev`) でアプリを起動しておく。
- サムネイル ID はレスポンスの `thumbnailId` を控えておき、後続のリクエストで利用する。
- サムネイル新規作成 (POST /api/crud/thumbnail)
  - curl -X POST -H "Content-Type: application/json" -d ''{"thumbnailPath":"/tmp/thumb.png"}'' http://localhost:${APP_PORT:-8080}/api/crud/thumbnail

- サムネイル一覧取得 (GET /api/crud/thumbnails)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/thumbnails

- サムネイル個別取得 (GET /api/crud/thumbnail/{thumbnailId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>

- サムネイル情報更新 (PUT /api/crud/thumbnail/{thumbnailId})
  - curl -X PUT -H "Content-Type: application/json" -d ''{"thumbnailPath":"/tmp/thumb-updated.png"}'' http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>

- サムネイル削除 (DELETE /api/crud/thumbnail/{thumbnailId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>


### 関連Issue
close #16  