### PR TITLE
feat:storiesテーブルの実装

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 *.java text eol=lf
 *.gradle text eol=lf
+*.sql text eol=lf
 *.md text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryService.java
@@ -1,0 +1,130 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** ストーリー周辺のユースケースを提供するアプリケーションサービス。 */
+@Service
+public class StoryService {
+
+  private final StoryRepository storyRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+  private final ThumbnailRepository thumbnailRepository;
+
+  public StoryService(
+      StoryRepository storyRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider,
+      ThumbnailRepository thumbnailRepository) {
+    this.storyRepository = storyRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+    this.thumbnailRepository = thumbnailRepository;
+  }
+
+  /**
+   * すべてのストーリーを取得する。
+   *
+   * @return ストーリー一覧
+   */
+  public List<Story> findAll() {
+    return storyRepository.findAll();
+  }
+
+  /**
+   * ストーリーを ID 指定で取得する。
+   *
+   * @param storyId ストーリー ID
+   * @return 見つかったストーリー（存在しない場合は空）
+   */
+  public Optional<Story> findById(String storyId) {
+    return storyRepository.findById(storyId);
+  }
+
+  /**
+   * ストーリーを新規作成する。
+   *
+   * @param auth0UserId 作成者の Auth0 ID
+   * @param storyTitle ストーリータイトル
+   * @param thumbnailId 紐付けるサムネイル ID（任意）
+   * @return 作成されたストーリー
+   */
+  @Transactional
+  public Story create(String auth0UserId, String storyTitle, String thumbnailId) {
+    Instant now = timeProvider.nowInstant();
+    Story story =
+        new Story(
+            uuidGeneratorService.generateV7(), auth0UserId, storyTitle, thumbnailId, now, now);
+    return storyRepository.save(story);
+  }
+
+  /**
+   * 既存ストーリーの内容を更新する。
+   *
+   * @param storyId ストーリー ID
+   * @param storyTitle 更新後のタイトル
+   * @param thumbnailId 更新後のサムネイル ID（任意）
+   * @return 更新後のストーリー（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<Story> update(String storyId, StoryUpdateCommand command) {
+    Instant updatedAt = timeProvider.nowInstant();
+    return storyRepository
+        .findById(storyId)
+        .map(
+            existing -> {
+              String nextTitle = existing.storyTitle();
+              if (command.storyTitleSpecified()) {
+                String candidate = command.storyTitle();
+                if (candidate != null && !candidate.isBlank()) {
+                  nextTitle = candidate;
+                }
+              }
+
+              String nextThumbnail = existing.thumbnailId();
+              if (command.thumbnailIdSpecified()) {
+                String candidate = command.thumbnailId();
+                if (candidate == null || candidate.isBlank()) {
+                  nextThumbnail = null;
+                } else {
+                  boolean exists = thumbnailRepository.findById(candidate).isPresent();
+                  if (!exists) {
+                    throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "thumbnailId does not exist: " + candidate);
+                  }
+                  nextThumbnail = candidate;
+                }
+              }
+
+              return new Story(
+                  storyId,
+                  existing.auth0UserId(),
+                  nextTitle,
+                  nextThumbnail,
+                  existing.createdAt(),
+                  updatedAt);
+            })
+        .map(storyRepository::save);
+  }
+
+  /**
+   * ストーリーを削除する。
+   *
+   * @param storyId ストーリー ID
+   */
+  @Transactional
+  public void delete(String storyId) {
+    storyRepository.deleteById(storyId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryUpdateCommand.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryUpdateCommand.java
@@ -1,0 +1,15 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+/**
+ * ストーリー更新で利用するコマンドオブジェクト。
+ *
+ * @param storyTitleSpecified タイトルがリクエストに含まれているか
+ * @param storyTitle 値（null またはブランクの場合は更新しない）
+ * @param thumbnailIdSpecified サムネイル ID が含まれているか
+ * @param thumbnailId 更新に使用するサムネイル ID（空文字も仕様上許容）
+ */
+public record StoryUpdateCommand(
+    boolean storyTitleSpecified,
+    String storyTitle,
+    boolean thumbnailIdSpecified,
+    String thumbnailId) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/Story.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/Story.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.story;
+
+import java.time.Instant;
+
+/**
+ * ストーリー情報を表すドメインモデル。
+ *
+ * <p>ユーザー ID・タイトル・サムネイル ID を保持し、アプリケーション層とのデータ授受に利用する。
+ */
+public record Story(
+    String storyId,
+    String auth0UserId,
+    String storyTitle,
+    String thumbnailId,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/StoryRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/StoryRepository.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.story;
+
+import java.util.List;
+import java.util.Optional;
+
+/** ストーリー永続化へアクセスするための抽象リポジトリ。 */
+public interface StoryRepository {
+
+  Optional<Story> findById(String storyId);
+
+  List<Story> findAll();
+
+  Story save(Story story);
+
+  void deleteById(String storyId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryEntity.java
@@ -1,0 +1,93 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** stories テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "stories")
+public class StoryEntity {
+
+  /** ストーリーを一意に識別するカラム。 */
+  @Id
+  @Column(name = "story_id", length = 255, nullable = false)
+  private String storyId;
+
+  /** ストーリー作成者の Auth0 ID。 */
+  @Column(name = "auth0_user_id", length = 255, nullable = false)
+  private String auth0UserId;
+
+  /** ストーリータイトル。 */
+  @Column(name = "story_title", length = 255, nullable = false)
+  private String storyTitle;
+
+  /** サムネイル ID（任意）。 */
+  @Column(name = "thumbnail_id", length = 255)
+  private String thumbnailId;
+
+  /** レコード作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  /** レコード更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  /** JPA が利用するデフォルトコンストラクタ。 */
+  protected StoryEntity() {}
+
+  public StoryEntity(
+      String storyId,
+      String auth0UserId,
+      String storyTitle,
+      String thumbnailId,
+      Instant createdAt,
+      Instant updatedAt) {
+    this.storyId = storyId;
+    this.auth0UserId = auth0UserId;
+    this.storyTitle = storyTitle;
+    this.thumbnailId = thumbnailId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getStoryId() {
+    return storyId;
+  }
+
+  public String getAuth0UserId() {
+    return auth0UserId;
+  }
+
+  public String getStoryTitle() {
+    return storyTitle;
+  }
+
+  public String getThumbnailId() {
+    return thumbnailId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
+   * タイトルとサムネイル ID を変更し、更新日時を反映させる。
+   *
+   * @param newTitle 更新後のタイトル
+   * @param newThumbnailId 更新後のサムネイル ID
+   * @param newUpdatedAt 更新日時
+   */
+  public void updateDetails(String newTitle, String newThumbnailId, Instant newUpdatedAt) {
+    this.storyTitle = newTitle;
+    this.thumbnailId = newThumbnailId;
+    this.updatedAt = newUpdatedAt;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryJpaRepository.java
@@ -1,0 +1,6 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** stories テーブルにアクセスする Spring Data JPA リポジトリ。 */
+public interface StoryJpaRepository extends JpaRepository<StoryEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryMapper.java
@@ -1,0 +1,35 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story;
+
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+
+/** ストーリーのドメインモデルとエンティティを相互変換するユーティリティ。 */
+public final class StoryMapper {
+
+  private StoryMapper() {}
+
+  public static Story toDomain(StoryEntity entity) {
+    return new Story(
+        entity.getStoryId(),
+        entity.getAuth0UserId(),
+        entity.getStoryTitle(),
+        entity.getThumbnailId(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  public static StoryEntity toEntity(Story story) {
+    return new StoryEntity(
+        story.storyId(),
+        story.auth0UserId(),
+        story.storyTitle(),
+        story.thumbnailId(),
+        story.createdAt(),
+        story.updatedAt());
+  }
+
+  public static StoryEntity toEntityForUpdate(
+      StoryEntity entity, String storyTitle, String thumbnailId, java.time.Instant updatedAt) {
+    entity.updateDetails(storyTitle, thumbnailId, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryRepositoryImpl.java
@@ -1,0 +1,52 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story;
+
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** StoryRepository を JPA で実装したクラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class StoryRepositoryImpl implements StoryRepository {
+
+  private final StoryJpaRepository storyJpaRepository;
+
+  public StoryRepositoryImpl(StoryJpaRepository storyJpaRepository) {
+    this.storyJpaRepository = storyJpaRepository;
+  }
+
+  @Override
+  public Optional<Story> findById(String storyId) {
+    return storyJpaRepository.findById(storyId).map(StoryMapper::toDomain);
+  }
+
+  @Override
+  public List<Story> findAll() {
+    return storyJpaRepository.findAll().stream().map(StoryMapper::toDomain).toList();
+  }
+
+  @Override
+  @Transactional
+  public Story save(Story story) {
+    StoryEntity entity =
+        storyJpaRepository
+            .findById(story.storyId())
+            .map(
+                existing ->
+                    StoryMapper.toEntityForUpdate(
+                        existing, story.storyTitle(), story.thumbnailId(), story.updatedAt()))
+            .orElse(StoryMapper.toEntity(story));
+
+    StoryEntity saved = storyJpaRepository.save(entity);
+    return StoryMapper.toDomain(saved);
+  }
+
+  @Override
+  @Transactional
+  public void deleteById(String storyId) {
+    storyJpaRepository.deleteById(storyId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevStoryCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevStoryCrudController.java
@@ -1,0 +1,173 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryService;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryUpdateCommand;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ストーリー向けの開発用 CRUD API を提供するコントローラ。
+ *
+ * <p>ユーザー CRUD と同じ命名規則でルーティングし、動作確認を容易にする。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevStoryCrudController {
+
+  private final StoryService storyService;
+  private final TimeProvider timeProvider;
+
+  public DevStoryCrudController(StoryService storyService, TimeProvider timeProvider) {
+    this.storyService = storyService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** ストーリーを全件取得する。 */
+  @GetMapping("/stories")
+  @PreAuthorize("permitAll()")
+  public List<StoryResponse> list() {
+    return storyService.findAll().stream().map(this::toResponse).toList();
+  }
+
+  /** ストーリーを 1 件取得する。 */
+  @GetMapping("/story/{storyId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<StoryResponse> get(@PathVariable String storyId) {
+    return storyService
+        .findById(storyId)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** ストーリーを新規作成する。 */
+  @PostMapping("/story")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<StoryResponse> create(@Valid @RequestBody StoryCreateRequest request) {
+    Story created =
+        storyService.create(request.auth0Id(), request.storyTitle(), request.thumbnailId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
+  }
+
+  /** 既存ストーリーを更新する。 */
+  @PutMapping("/story/{storyId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<StoryResponse> update(
+      @PathVariable String storyId, @Valid @RequestBody StoryUpdateRequest request) {
+    if (request.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    StoryUpdateCommand command =
+        new StoryUpdateCommand(
+            request.storyTitleSpecified(),
+            request.storyTitle(),
+            request.thumbnailIdSpecified(),
+            request.thumbnailId());
+
+    return storyService
+        .update(storyId, command)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** ストーリーを削除する。 */
+  @DeleteMapping("/story/{storyId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String storyId) {
+    storyService.delete(storyId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private StoryResponse toResponse(Story story) {
+    return new StoryResponse(
+        story.storyId(),
+        story.auth0UserId(),
+        story.storyTitle(),
+        story.thumbnailId(),
+        timeProvider.formatIso(story.createdAt()),
+        timeProvider.formatIso(story.updatedAt()));
+  }
+
+  /** ストーリー作成リクエスト。 */
+  public record StoryCreateRequest(
+      @NotBlank String auth0Id,
+      @NotBlank @Size(max = 255) String storyTitle,
+      @Size(max = 255) String thumbnailId) {}
+
+  /** ストーリー更新リクエスト。 */
+  public static class StoryUpdateRequest {
+
+    @Size(max = 255)
+    private String storyTitle;
+
+    private boolean storyTitleSpecified;
+
+    @Size(max = 255)
+    private String thumbnailId;
+
+    private boolean thumbnailIdSpecified;
+
+    @JsonProperty("storyTitle")
+    public void setStoryTitle(String storyTitle) {
+      this.storyTitle = storyTitle;
+      this.storyTitleSpecified = true;
+    }
+
+    @JsonProperty("thumbnailId")
+    public void setThumbnailId(String thumbnailId) {
+      this.thumbnailId = thumbnailId;
+      this.thumbnailIdSpecified = true;
+    }
+
+    public String storyTitle() {
+      return storyTitle;
+    }
+
+    public String thumbnailId() {
+      return thumbnailId;
+    }
+
+    public boolean storyTitleSpecified() {
+      return storyTitleSpecified;
+    }
+
+    public boolean thumbnailIdSpecified() {
+      return thumbnailIdSpecified;
+    }
+
+    boolean isEmpty() {
+      return !storyTitleSpecified && !thumbnailIdSpecified;
+    }
+  }
+
+  /** ストーリーのレスポンス DTO。 */
+  public record StoryResponse(
+      String storyId,
+      String auth0Id,
+      String storyTitle,
+      String thumbnailId,
+      String createdAt,
+      String updatedAt) {}
+}

--- a/app/src/main/resources/db/migration/V3__create_stories.sql
+++ b/app/src/main/resources/db/migration/V3__create_stories.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS stories (
+    story_id VARCHAR(255) PRIMARY KEY,
+    auth0_user_id VARCHAR(255) NOT NULL,
+    story_title VARCHAR(255) NOT NULL,
+    thumbnail_id VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT fk_stories_users FOREIGN KEY (auth0_user_id) REFERENCES users (auth0_user_id),
+    CONSTRAINT fk_stories_thumbnails FOREIGN KEY (thumbnail_id) REFERENCES thumbnails (thumbnail_id)
+);
+
+CREATE OR REPLACE FUNCTION set_stories_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_stories_updated_at ON stories;
+CREATE TRIGGER trg_stories_updated_at
+    BEFORE UPDATE ON stories
+    FOR EACH ROW EXECUTE FUNCTION set_stories_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevStoryCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevStoryCrudControllerTest.java
@@ -1,0 +1,176 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.application.user.UserService;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/** ストーリー CRUD API の基本的な動作を確認する統合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevStoryCrudControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserService userService;
+  @Autowired private ThumbnailService thumbnailService;
+
+  private String auth0Id;
+  private String initialThumbnailId;
+
+  @BeforeEach
+  void setUp() {
+    auth0Id = "auth0|story-crud";
+    userService.findOrCreate(auth0Id);
+    Thumbnail thumbnail = thumbnailService.create("/path/to/story-thumb.png");
+    initialThumbnailId = thumbnail.thumbnailId();
+  }
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    String storyTitle = "My First Story";
+
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("auth0Id", auth0Id);
+    createRequest.put("storyTitle", storyTitle);
+    createRequest.put("thumbnailId", initialThumbnailId);
+
+    // Create
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/story")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.storyTitle").value(storyTitle))
+            .andExpect(jsonPath("$.thumbnailId").value(initialThumbnailId))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String storyId = created.get("storyId").toString();
+
+    // List
+    mockMvc
+        .perform(get("/api/crud/stories"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].storyId").exists());
+
+    // Get
+    mockMvc
+        .perform(get("/api/crud/story/" + storyId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.storyId").value(storyId))
+        .andExpect(jsonPath("$.auth0Id").value(auth0Id));
+
+    // Update
+    String updatedTitle = "Updated Story Title";
+
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("storyTitle", updatedTitle);
+
+    mockMvc
+        .perform(
+            put("/api/crud/story/" + storyId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.storyTitle").value(updatedTitle))
+        .andExpect(jsonPath("$.thumbnailId").value(initialThumbnailId));
+
+    // Delete
+    mockMvc.perform(delete("/api/crud/story/" + storyId)).andExpect(status().isNoContent());
+  }
+
+  @Test
+  void skipsUpdatingNonNullableTitleWhenBlank() throws Exception {
+    String storyId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/story")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of(
+                                        "auth0Id", auth0Id,
+                                        "storyTitle", "Original Title",
+                                        "thumbnailId", initialThumbnailId))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("storyId")
+            .asText();
+
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("storyTitle", "");
+    updateRequest.put("thumbnailId", "");
+
+    mockMvc
+        .perform(
+            put("/api/crud/story/" + storyId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.storyTitle").value("Original Title"))
+        .andExpect(jsonPath("$.thumbnailId").doesNotExist());
+  }
+
+  @Test
+  void returnsBadRequestWhenThumbnailDoesNotExist() throws Exception {
+    String storyId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/story")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of(
+                                        "auth0Id", auth0Id,
+                                        "storyTitle", "Original Title",
+                                        "thumbnailId", initialThumbnailId))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("storyId")
+            .asText();
+
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("thumbnailId", "non-existent-thumb");
+
+    mockMvc
+        .perform(
+            put("/api/crud/story/" + storyId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
storiesテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Story CRUD API テスト
- 開発プロファイル (`SPRING_PROFILES_ACTIVE=dev`) で起動し、事前にユーザーとサムネイルを登録しておく。
- ストーリー新規作成 (POST /api/crud/story)
  - curl -X POST -H "Content-Type: application/json" -d '{"auth0Id":"auth0|story-test","storyTitle":"はじめてのストーリー","thumbnailId":"<thumbnailId>"}' http://localhost:${APP_PORT:-8080}/api/crud/story
- ストーリー一覧取得 (GET /api/crud/stories)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/stories
- ストーリー個別取得 (GET /api/crud/story/{storyId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/story/<storyId>
- ストーリー更新 (PUT /api/crud/story/{storyId})
  - curl -X PUT -H "Content-Type: application/json" -d '{"storyTitle":"更新後のタイトル","thumbnailId":"<thumbnailId>"}' http://localhost:${APP_PORT:-8080}/api/crud/story/<storyId>
- ストーリー削除 (DELETE /api/crud/story/{storyId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/story/<storyId>

### 関連Issue
close #17 