### PR TITLE
feat:chaptersテーブルの実装

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterService.java
@@ -1,0 +1,150 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * chapter テーブルへの CRUD 操作をまとめるアプリケーションサービス。
+ *
+ * <p>story 存在チェックや ID 採番など、ドメイン横断の責務を担当する。
+ */
+@Service
+public class ChapterService {
+
+  private final ChapterRepository chapterRepository;
+  private final StoryRepository storyRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+
+  public ChapterService(
+      ChapterRepository chapterRepository,
+      StoryRepository storyRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider) {
+    this.chapterRepository = chapterRepository;
+    this.storyRepository = storyRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+  }
+
+  /**
+   * 章の一覧を取得する。
+   *
+   * @return chapter 一覧
+   */
+  public List<Chapter> findAll() {
+    return chapterRepository.findAll();
+  }
+
+  /**
+   * 章 ID を指定して取得する。
+   *
+   * @param chapterId 章 ID
+   * @return 該当章（存在しない場合は空）
+   */
+  public Optional<Chapter> findById(String chapterId) {
+    return chapterRepository.findById(chapterId);
+  }
+
+  /**
+   * 章を新規作成する。
+   *
+   * @param storyId 紐付ける story ID
+   * @param chapterNum 章番号
+   * @param chapterText 本文
+   * @return 作成した章
+   */
+  @Transactional
+  public Chapter create(String storyId, int chapterNum, String chapterText) {
+    ensureStoryExists(storyId);
+
+    Instant now = timeProvider.nowInstant();
+    Chapter chapter =
+        new Chapter(uuidGeneratorService.generateV7(), storyId, chapterNum, chapterText, now, now);
+    return chapterRepository.save(chapter);
+  }
+
+  /**
+   * 章を更新する。
+   *
+   * @param chapterId 章 ID
+   * @param command 更新内容
+   * @return 更新後の章（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<Chapter> update(String chapterId, ChapterUpdateCommand command) {
+    return chapterRepository
+        .findById(chapterId)
+        .map(existing -> applyUpdate(existing, command))
+        .map(chapterRepository::save);
+  }
+
+  /**
+   * 章を削除する。
+   *
+   * @param chapterId 章 ID
+   */
+  @Transactional
+  public void delete(String chapterId) {
+    chapterRepository.deleteById(chapterId);
+  }
+
+  private Chapter applyUpdate(Chapter existing, ChapterUpdateCommand command) {
+    String nextStoryId = existing.storyId();
+    if (command.storyIdSpecified()) {
+      String candidate = command.storyId();
+      if (!StringUtils.hasText(candidate)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "storyId must not be blank");
+      }
+      ensureStoryExists(candidate);
+      nextStoryId = candidate;
+    }
+
+    int nextChapterNum = existing.chapterNum();
+    if (command.chapterNumSpecified()) {
+      Integer candidate = command.chapterNum();
+      if (candidate == null || candidate < 1) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "chapterNum must be greater than or equal to 1");
+      }
+      nextChapterNum = candidate;
+    }
+
+    String nextChapterText = existing.chapterText();
+    if (command.chapterTextSpecified()) {
+      String candidate = command.chapterText();
+      if (!StringUtils.hasText(candidate)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterText must not be blank");
+      }
+      nextChapterText = candidate;
+    }
+
+    Instant updatedAt = timeProvider.nowInstant();
+    return new Chapter(
+        existing.chapterId(),
+        nextStoryId,
+        nextChapterNum,
+        nextChapterText,
+        existing.createdAt(),
+        updatedAt);
+  }
+
+  private void ensureStoryExists(String storyId) {
+    boolean exists = storyRepository.findById(storyId).isPresent();
+    if (!exists) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "storyId does not exist: " + storyId);
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterUpdateCommand.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterUpdateCommand.java
@@ -1,0 +1,19 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+/**
+ * 章情報を更新するときに利用するコマンドオブジェクト。
+ *
+ * @param storyIdSpecified storyId がリクエストに含まれていたか
+ * @param storyId 更新後の storyId（null や空文字の場合はエラー）
+ * @param chapterNumSpecified chapterNum が含まれていたか
+ * @param chapterNum 更新後の章番号（null や 1 未満はエラー）
+ * @param chapterTextSpecified chapterText が含まれていたか
+ * @param chapterText 更新後の本文（null / 空文字はエラー）
+ */
+public record ChapterUpdateCommand(
+    boolean storyIdSpecified,
+    String storyId,
+    boolean chapterNumSpecified,
+    Integer chapterNum,
+    boolean chapterTextSpecified,
+    String chapterText) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/Chapter.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/Chapter.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.chapter;
+
+import java.time.Instant;
+
+/**
+ * 章(chapter)情報を保持するドメインオブジェクト。
+ *
+ * <p>story との紐付けや章番号・本文・作成/更新日時などを集約して扱う。
+ */
+public record Chapter(
+    String chapterId,
+    String storyId,
+    int chapterNum,
+    String chapterText,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/ChapterRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/ChapterRepository.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.chapter;
+
+import java.util.List;
+import java.util.Optional;
+
+/** chapter テーブルへアクセスするための抽象リポジトリ。 */
+public interface ChapterRepository {
+
+  Optional<Chapter> findById(String chapterId);
+
+  List<Chapter> findAll();
+
+  Chapter save(Chapter chapter);
+
+  void deleteById(String chapterId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterEntity.java
@@ -1,0 +1,96 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** chapters テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "chapters")
+public class ChapterEntity {
+
+  /** 章 ID。 */
+  @Id
+  @Column(name = "chapter_id", length = 255, nullable = false)
+  private String chapterId;
+
+  /** 紐付く story ID。 */
+  @Column(name = "story_id", length = 255, nullable = false)
+  private String storyId;
+
+  /** 章番号。 */
+  @Column(name = "chapter_num", nullable = false)
+  private int chapterNum;
+
+  /** 章本文。 */
+  @Column(name = "chapter_text", nullable = false, columnDefinition = "TEXT")
+  private String chapterText;
+
+  /** 作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  /** 更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  /** JPA が利用するデフォルトコンストラクタ。 */
+  protected ChapterEntity() {}
+
+  public ChapterEntity(
+      String chapterId,
+      String storyId,
+      int chapterNum,
+      String chapterText,
+      Instant createdAt,
+      Instant updatedAt) {
+    this.chapterId = chapterId;
+    this.storyId = storyId;
+    this.chapterNum = chapterNum;
+    this.chapterText = chapterText;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getChapterId() {
+    return chapterId;
+  }
+
+  public String getStoryId() {
+    return storyId;
+  }
+
+  public int getChapterNum() {
+    return chapterNum;
+  }
+
+  public String getChapterText() {
+    return chapterText;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
+   * story ID / 章番号 / 本文 を更新し、更新日時を反映する。
+   *
+   * @param newStoryId 更新後の story ID
+   * @param newChapterNum 更新後の章番号
+   * @param newChapterText 更新後の本文
+   * @param newUpdatedAt 更新日時
+   */
+  public void updateDetails(
+      String newStoryId, int newChapterNum, String newChapterText, Instant newUpdatedAt) {
+    this.storyId = newStoryId;
+    this.chapterNum = newChapterNum;
+    this.chapterText = newChapterText;
+    this.updatedAt = newUpdatedAt;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterJpaRepository.java
@@ -1,0 +1,6 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** chapters テーブルへアクセスする Spring Data JPA リポジトリ。 */
+public interface ChapterJpaRepository extends JpaRepository<ChapterEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterMapper.java
@@ -1,0 +1,36 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter;
+
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import java.time.Instant;
+
+/** chapter のドメイン ↔ エンティティを変換するユーティリティ。 */
+public final class ChapterMapper {
+
+  private ChapterMapper() {}
+
+  public static Chapter toDomain(ChapterEntity entity) {
+    return new Chapter(
+        entity.getChapterId(),
+        entity.getStoryId(),
+        entity.getChapterNum(),
+        entity.getChapterText(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  public static ChapterEntity toEntity(Chapter chapter) {
+    return new ChapterEntity(
+        chapter.chapterId(),
+        chapter.storyId(),
+        chapter.chapterNum(),
+        chapter.chapterText(),
+        chapter.createdAt(),
+        chapter.updatedAt());
+  }
+
+  public static ChapterEntity toEntityForUpdate(
+      ChapterEntity entity, String storyId, int chapterNum, String chapterText, Instant updatedAt) {
+    entity.updateDetails(storyId, chapterNum, chapterText, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterRepositoryImpl.java
@@ -1,0 +1,56 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter;
+
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** ChapterRepository を JPA で実現する実装クラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class ChapterRepositoryImpl implements ChapterRepository {
+
+  private final ChapterJpaRepository chapterJpaRepository;
+
+  public ChapterRepositoryImpl(ChapterJpaRepository chapterJpaRepository) {
+    this.chapterJpaRepository = chapterJpaRepository;
+  }
+
+  @Override
+  public Optional<Chapter> findById(String chapterId) {
+    return chapterJpaRepository.findById(chapterId).map(ChapterMapper::toDomain);
+  }
+
+  @Override
+  public List<Chapter> findAll() {
+    return chapterJpaRepository.findAll().stream().map(ChapterMapper::toDomain).toList();
+  }
+
+  @Override
+  @Transactional
+  public Chapter save(Chapter chapter) {
+    ChapterEntity entity =
+        chapterJpaRepository
+            .findById(chapter.chapterId())
+            .map(
+                existing ->
+                    ChapterMapper.toEntityForUpdate(
+                        existing,
+                        chapter.storyId(),
+                        chapter.chapterNum(),
+                        chapter.chapterText(),
+                        chapter.updatedAt()))
+            .orElse(ChapterMapper.toEntity(chapter));
+
+    ChapterEntity saved = chapterJpaRepository.save(entity);
+    return ChapterMapper.toDomain(saved);
+  }
+
+  @Override
+  @Transactional
+  public void deleteById(String chapterId) {
+    chapterJpaRepository.deleteById(chapterId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevChapterCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevChapterCrudController.java
@@ -1,0 +1,184 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterUpdateCommand;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 章(chapter)向けの開発用 CRUD API を提供するコントローラ。
+ *
+ * <p>stories CRUD と同様、dev プロファイル限定で動作させ、手動確認や Postman から利用する。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevChapterCrudController {
+
+  private final ChapterService chapterService;
+  private final TimeProvider timeProvider;
+
+  public DevChapterCrudController(ChapterService chapterService, TimeProvider timeProvider) {
+    this.chapterService = chapterService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** 章一覧を返す。 */
+  @GetMapping("/chapters")
+  @PreAuthorize("permitAll()")
+  public List<ChapterResponse> list() {
+    return chapterService.findAll().stream().map(this::toResponse).toList();
+  }
+
+  /** 指定した章を取得する。 */
+  @GetMapping("/chapter/{chapterId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ChapterResponse> get(@PathVariable String chapterId) {
+    return chapterService
+        .findById(chapterId)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** 章を新規作成する。 */
+  @PostMapping("/chapter")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ChapterResponse> create(@Valid @RequestBody ChapterCreateRequest request) {
+    Chapter created =
+        chapterService.create(request.storyId(), request.chapterNum(), request.chapterText());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
+  }
+
+  /** 章の内容を更新する。 */
+  @PutMapping("/chapter/{chapterId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ChapterResponse> update(
+      @PathVariable String chapterId, @Valid @RequestBody ChapterUpdateRequest request) {
+    if (request.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    ChapterUpdateCommand command =
+        new ChapterUpdateCommand(
+            request.storyIdSpecified(),
+            request.storyId(),
+            request.chapterNumSpecified(),
+            request.chapterNum(),
+            request.chapterTextSpecified(),
+            request.chapterText());
+
+    return chapterService
+        .update(chapterId, command)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** 章を削除する。 */
+  @DeleteMapping("/chapter/{chapterId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String chapterId) {
+    chapterService.delete(chapterId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private ChapterResponse toResponse(Chapter chapter) {
+    return new ChapterResponse(
+        chapter.chapterId(),
+        chapter.storyId(),
+        chapter.chapterNum(),
+        chapter.chapterText(),
+        timeProvider.formatIso(chapter.createdAt()),
+        timeProvider.formatIso(chapter.updatedAt()));
+  }
+
+  /** 章作成リクエスト。 */
+  public record ChapterCreateRequest(
+      @NotBlank String storyId, @Min(1) int chapterNum, @NotBlank String chapterText) {}
+
+  /** 章更新リクエスト。 */
+  public static class ChapterUpdateRequest {
+
+    private String storyId;
+    private boolean storyIdSpecified;
+    private Integer chapterNum;
+    private boolean chapterNumSpecified;
+    private String chapterText;
+    private boolean chapterTextSpecified;
+
+    @JsonProperty("storyId")
+    public void setStoryId(String storyId) {
+      this.storyId = storyId;
+      this.storyIdSpecified = true;
+    }
+
+    @JsonProperty("chapterNum")
+    public void setChapterNum(Integer chapterNum) {
+      this.chapterNum = chapterNum;
+      this.chapterNumSpecified = true;
+    }
+
+    @JsonProperty("chapterText")
+    public void setChapterText(String chapterText) {
+      this.chapterText = chapterText;
+      this.chapterTextSpecified = true;
+    }
+
+    public String storyId() {
+      return storyId;
+    }
+
+    public Integer chapterNum() {
+      return chapterNum;
+    }
+
+    public String chapterText() {
+      return chapterText;
+    }
+
+    public boolean storyIdSpecified() {
+      return storyIdSpecified;
+    }
+
+    public boolean chapterNumSpecified() {
+      return chapterNumSpecified;
+    }
+
+    public boolean chapterTextSpecified() {
+      return chapterTextSpecified;
+    }
+
+    boolean isEmpty() {
+      return !storyIdSpecified && !chapterNumSpecified && !chapterTextSpecified;
+    }
+  }
+
+  /** 章レスポンス DTO。 */
+  public record ChapterResponse(
+      String chapterId,
+      String storyId,
+      int chapterNum,
+      String chapterText,
+      String createdAt,
+      String updatedAt) {}
+}

--- a/app/src/main/resources/db/migration/V4__create_chapters.sql
+++ b/app/src/main/resources/db/migration/V4__create_chapters.sql
@@ -1,0 +1,24 @@
+-- 章(chapters)テーブルを作成するマイグレーション
+CREATE TABLE IF NOT EXISTS chapters (
+    chapter_id VARCHAR(255) PRIMARY KEY,
+    story_id VARCHAR(255) NOT NULL,
+    chapter_num INT NOT NULL,
+    chapter_text TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT fk_chapters_stories FOREIGN KEY (story_id) REFERENCES stories (story_id)
+);
+
+-- stories との整合性確保と更新日時の自動更新に関するトリガー定義
+CREATE OR REPLACE FUNCTION set_chapters_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_chapters_updated_at ON chapters;
+CREATE TRIGGER trg_chapters_updated_at
+    BEFORE UPDATE ON chapters
+    FOR EACH ROW EXECUTE FUNCTION set_chapters_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevChapterCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevChapterCrudControllerTest.java
@@ -1,0 +1,161 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.application.user.UserService;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/** chapter CRUD API の基本挙動を確認する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevChapterCrudControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserService userService;
+  @Autowired private ThumbnailService thumbnailService;
+  @Autowired private StoryService storyService;
+
+  private String auth0Id;
+  private String baseStoryId;
+  private String secondaryStoryId;
+
+  @BeforeEach
+  void setUp() {
+    auth0Id = "auth0|chapter-crud";
+    userService.findOrCreate(auth0Id);
+    Thumbnail thumbnail = thumbnailService.create("/path/to/chapter-thumb.png");
+
+    Story baseStory = storyService.create(auth0Id, "Base Story", thumbnail.thumbnailId());
+    baseStoryId = baseStory.storyId();
+
+    Story secondaryStory = storyService.create(auth0Id, "Secondary Story", thumbnail.thumbnailId());
+    secondaryStoryId = secondaryStory.storyId();
+  }
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("storyId", baseStoryId);
+    createRequest.put("chapterNum", 1);
+    createRequest.put("chapterText", "First scene");
+
+    // Create
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/chapter")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.storyId").value(baseStoryId))
+            .andExpect(jsonPath("$.chapterNum").value(1))
+            .andExpect(jsonPath("$.chapterText").value("First scene"))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String chapterId = created.get("chapterId").toString();
+
+    // List
+    mockMvc.perform(get("/api/crud/chapters")).andExpect(status().isOk());
+
+    // Get
+    mockMvc
+        .perform(get("/api/crud/chapter/" + chapterId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.chapterId").value(chapterId))
+        .andExpect(jsonPath("$.storyId").value(baseStoryId));
+
+    // Update
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("chapterNum", 2);
+    updateRequest.put("chapterText", "Second scene");
+    updateRequest.put("storyId", secondaryStoryId);
+
+    mockMvc
+        .perform(
+            put("/api/crud/chapter/" + chapterId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.chapterNum").value(2))
+        .andExpect(jsonPath("$.chapterText").value("Second scene"))
+        .andExpect(jsonPath("$.storyId").value(secondaryStoryId));
+
+    // Delete
+    mockMvc.perform(delete("/api/crud/chapter/" + chapterId)).andExpect(status().isNoContent());
+  }
+
+  @Test
+  void returnsBadRequestWhenStoryDoesNotExist() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("storyId", "non-existent-story");
+    createRequest.put("chapterNum", 1);
+    createRequest.put("chapterText", "Body");
+
+    mockMvc
+        .perform(
+            post("/api/crud/chapter")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsBlankChapterTextOnUpdate() throws Exception {
+    String chapterId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/chapter")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of(
+                                        "storyId",
+                                        baseStoryId,
+                                        "chapterNum",
+                                        3,
+                                        "chapterText",
+                                        "Original text"))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("chapterId")
+            .asText();
+
+    mockMvc
+        .perform(
+            put("/api/crud/chapter/" + chapterId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("chapterText", ""))))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
chaptersテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Chapter CRUD API テスト
- dev プロファイルで起動し、事前にユーザー / サムネイル / ストーリーを1件ずつ登録して storyId を把握しておく。
- 章の新規作成 (POST /api/crud/chapter)
  - curl -X POST -H "Content-Type: application/json" -d '{"storyId":"<storyId>","chapterNum":1,"chapterText":"章本文"}' http://localhost:${APP_PORT:-8080}/api/crud/chapter
- 章一覧取得 (GET /api/crud/chapters)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/chapters
- 章詳細取得 (GET /api/crud/chapter/{chapterId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/chapter/<chapterId>
- 章更新 (PUT /api/crud/chapter/{chapterId})
  - curl -X PUT -H "Content-Type: application/json" -d '{"chapterNum":2,"chapterText":"更新後の本文"}' http://localhost:${APP_PORT:-8080}/api/crud/chapter/<chapterId>
- 章削除 (DELETE /api/crud/chapter/{chapterId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/chapter/<chapterId>

### 関連Issue
close #18 