### PR TITLE
feat:keywordsテーブルの実装

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/keyword/KeywordService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/keyword/KeywordService.java
@@ -1,0 +1,165 @@
+package io.github.tempsotsusei.kotobanotane.application.keyword;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import io.github.tempsotsusei.kotobanotane.domain.keyword.Keyword;
+import io.github.tempsotsusei.kotobanotane.domain.keyword.KeywordRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * keyword テーブルへの CRUD 操作を取りまとめるアプリケーションサービス。
+ *
+ * <p>章の存在検証や必須項目のバリデーションを担当する。
+ */
+@Service
+public class KeywordService {
+
+  private final KeywordRepository keywordRepository;
+  private final ChapterRepository chapterRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+
+  public KeywordService(
+      KeywordRepository keywordRepository,
+      ChapterRepository chapterRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider) {
+    this.keywordRepository = keywordRepository;
+    this.chapterRepository = chapterRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+  }
+
+  /**
+   * キーワード一覧を取得する。
+   *
+   * @return keyword 一覧
+   */
+  public List<Keyword> findAll() {
+    return keywordRepository.findAll();
+  }
+
+  /**
+   * キーワード ID で取得する。
+   *
+   * @param keywordId キーワード ID
+   * @return 該当 keyword（存在しない場合は空）
+   */
+  public Optional<Keyword> findById(String keywordId) {
+    return keywordRepository.findById(keywordId);
+  }
+
+  /**
+   * 新規キーワードを登録する。
+   *
+   * @param chapterId 紐付ける章 ID
+   * @param keywordValue キーワード本文
+   * @param keywordPosition 表示順
+   * @return 登録した keyword
+   */
+  @Transactional
+  public Keyword create(String chapterId, String keywordValue, int keywordPosition) {
+    validateChapterExists(chapterId);
+    ensureKeywordValue(keywordValue);
+    ensurePosition(keywordPosition);
+
+    Instant now = timeProvider.nowInstant();
+    Keyword keyword =
+        new Keyword(
+            uuidGeneratorService.generateV7(), chapterId, keywordValue, keywordPosition, now, now);
+    return keywordRepository.save(keyword);
+  }
+
+  /**
+   * キーワード情報を更新する。
+   *
+   * @param keywordId キーワード ID
+   * @param command 更新内容
+   * @return 更新後 keyword（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<Keyword> update(String keywordId, KeywordUpdateCommand command) {
+    return keywordRepository
+        .findById(keywordId)
+        .map(existing -> applyUpdate(existing, command))
+        .map(keywordRepository::save);
+  }
+
+  /**
+   * キーワードを削除する。
+   *
+   * @param keywordId キーワード ID
+   */
+  @Transactional
+  public void delete(String keywordId) {
+    keywordRepository.deleteById(keywordId);
+  }
+
+  private Keyword applyUpdate(Keyword existing, KeywordUpdateCommand command) {
+    String nextChapterId = existing.chapterId();
+    if (command.chapterIdSpecified()) {
+      String candidate = command.chapterId();
+      if (!StringUtils.hasText(candidate)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterId must not be blank");
+      }
+      validateChapterExists(candidate);
+      nextChapterId = candidate;
+    }
+
+    String nextKeyword = existing.keyword();
+    if (command.keywordSpecified()) {
+      String candidate = command.keyword();
+      ensureKeywordValue(candidate);
+      nextKeyword = candidate;
+    }
+
+    int nextPosition = existing.keywordPosition();
+    if (command.keywordPositionSpecified()) {
+      Integer candidate = command.keywordPosition();
+      if (candidate == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "keywordPosition must not be null");
+      }
+      ensurePosition(candidate);
+      nextPosition = candidate;
+    }
+
+    Instant updatedAt = timeProvider.nowInstant();
+    return new Keyword(
+        existing.keywordId(),
+        nextChapterId,
+        nextKeyword,
+        nextPosition,
+        existing.createdAt(),
+        updatedAt);
+  }
+
+  private void validateChapterExists(String chapterId) {
+    boolean exists = chapterRepository.findById(chapterId).isPresent();
+    if (!exists) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterId does not exist: " + chapterId);
+    }
+  }
+
+  private void ensureKeywordValue(String keywordValue) {
+    if (!StringUtils.hasText(keywordValue)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "keyword must not be blank");
+    }
+  }
+
+  private void ensurePosition(int keywordPosition) {
+    if (keywordPosition < 1) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "keywordPosition must be greater than or equal to 1");
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/keyword/KeywordUpdateCommand.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/keyword/KeywordUpdateCommand.java
@@ -1,0 +1,19 @@
+package io.github.tempsotsusei.kotobanotane.application.keyword;
+
+/**
+ * キーワード更新時の差分情報を保持するコマンド。
+ *
+ * @param chapterIdSpecified chapterId がリクエストに含まれていたか
+ * @param chapterId 更新後の章 ID
+ * @param keywordSpecified keyword が含まれていたか
+ * @param keyword 更新後のキーワード文字列
+ * @param keywordPositionSpecified keywordPosition が含まれていたか
+ * @param keywordPosition 更新後の表示順
+ */
+public record KeywordUpdateCommand(
+    boolean chapterIdSpecified,
+    String chapterId,
+    boolean keywordSpecified,
+    String keyword,
+    boolean keywordPositionSpecified,
+    Integer keywordPosition) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/keyword/Keyword.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/keyword/Keyword.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.keyword;
+
+import java.time.Instant;
+
+/**
+ * キーワード(keyword)情報を保持するドメインオブジェクト。
+ *
+ * <p>紐付く章 ID・キーワード文字列・表示順などを一括で表現する。
+ */
+public record Keyword(
+    String keywordId,
+    String chapterId,
+    String keyword,
+    int keywordPosition,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/keyword/KeywordRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/keyword/KeywordRepository.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.keyword;
+
+import java.util.List;
+import java.util.Optional;
+
+/** keywords テーブルにアクセスするためのリポジトリアブストラクション。 */
+public interface KeywordRepository {
+
+  Optional<Keyword> findById(String keywordId);
+
+  List<Keyword> findAll();
+
+  Keyword save(Keyword keyword);
+
+  void deleteById(String keywordId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordEntity.java
@@ -1,0 +1,98 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.keyword;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/** keywords テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "keywords")
+public class KeywordEntity {
+
+	/** キーワード ID。 */
+	@Id
+	@Column(name = "keyword_id", length = 255, nullable = false)
+	private String keywordId;
+
+	/** 紐付く章 ID。 */
+	@Column(name = "chapter_id", length = 255, nullable = false)
+	private String chapterId;
+
+	/** キーワード文字列。 */
+	@Column(name = "keyword", length = 255, nullable = false)
+	private String keyword;
+
+	/** キーワードの出現文字数。 */
+	@Column(name = "keyword_position", nullable = false)
+	private int keywordPosition;
+
+	/** 作成日時。 */
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	/** 更新日時。 */
+	@Column(name = "updated_at")
+	private Instant updatedAt;
+
+	/** JPA が利用するデフォルトコンストラクタ。 */
+	protected KeywordEntity() {
+	}
+
+	public KeywordEntity(
+			String keywordId,
+			String chapterId,
+			String keyword,
+			int keywordPosition,
+			Instant createdAt,
+			Instant updatedAt) {
+		this.keywordId = keywordId;
+		this.chapterId = chapterId;
+		this.keyword = keyword;
+		this.keywordPosition = keywordPosition;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+
+	public String getKeywordId() {
+		return keywordId;
+	}
+
+	public String getChapterId() {
+		return chapterId;
+	}
+
+	public String getKeyword() {
+		return keyword;
+	}
+
+	public int getKeywordPosition() {
+		return keywordPosition;
+	}
+
+	public Instant getCreatedAt() {
+		return createdAt;
+	}
+
+	public Instant getUpdatedAt() {
+		return updatedAt;
+	}
+
+	/**
+	 * 章 ID・キーワード本文・表示順を変更し、更新日時を反映する。
+	 *
+	 * @param newChapterId       更新後の章 ID
+	 * @param newKeyword         更新後のキーワード本文
+	 * @param newKeywordPosition 更新後の表示順
+	 * @param newUpdatedAt       更新日時
+	 */
+	public void updateDetails(
+			String newChapterId, String newKeyword, int newKeywordPosition, Instant newUpdatedAt) {
+		this.chapterId = newChapterId;
+		this.keyword = newKeyword;
+		this.keywordPosition = newKeywordPosition;
+		this.updatedAt = newUpdatedAt;
+	}
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordJpaRepository.java
@@ -1,0 +1,6 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.keyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** keywords テーブルにアクセスする Spring Data JPA リポジトリ。 */
+public interface KeywordJpaRepository extends JpaRepository<KeywordEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordMapper.java
@@ -1,0 +1,36 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.keyword;
+
+import io.github.tempsotsusei.kotobanotane.domain.keyword.Keyword;
+import java.time.Instant;
+
+/** keyword ドメイン ↔ エンティティ変換を行うユーティリティ。 */
+public final class KeywordMapper {
+
+  private KeywordMapper() {}
+
+  public static Keyword toDomain(KeywordEntity entity) {
+    return new Keyword(
+        entity.getKeywordId(),
+        entity.getChapterId(),
+        entity.getKeyword(),
+        entity.getKeywordPosition(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  public static KeywordEntity toEntity(Keyword keyword) {
+    return new KeywordEntity(
+        keyword.keywordId(),
+        keyword.chapterId(),
+        keyword.keyword(),
+        keyword.keywordPosition(),
+        keyword.createdAt(),
+        keyword.updatedAt());
+  }
+
+  public static KeywordEntity toEntityForUpdate(
+      KeywordEntity entity, String chapterId, String keywordValue, int keywordPosition, Instant updatedAt) {
+    entity.updateDetails(chapterId, keywordValue, keywordPosition, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordRepositoryImpl.java
@@ -1,0 +1,56 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.keyword;
+
+import io.github.tempsotsusei.kotobanotane.domain.keyword.Keyword;
+import io.github.tempsotsusei.kotobanotane.domain.keyword.KeywordRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** KeywordRepository を JPA で実現する実装クラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class KeywordRepositoryImpl implements KeywordRepository {
+
+  private final KeywordJpaRepository keywordJpaRepository;
+
+  public KeywordRepositoryImpl(KeywordJpaRepository keywordJpaRepository) {
+    this.keywordJpaRepository = keywordJpaRepository;
+  }
+
+  @Override
+  public Optional<Keyword> findById(String keywordId) {
+    return keywordJpaRepository.findById(keywordId).map(KeywordMapper::toDomain);
+  }
+
+  @Override
+  public List<Keyword> findAll() {
+    return keywordJpaRepository.findAll().stream().map(KeywordMapper::toDomain).toList();
+  }
+
+  @Override
+  @Transactional
+  public Keyword save(Keyword keyword) {
+    KeywordEntity entity =
+        keywordJpaRepository
+            .findById(keyword.keywordId())
+            .map(
+                existing ->
+                    KeywordMapper.toEntityForUpdate(
+                        existing,
+                        keyword.chapterId(),
+                        keyword.keyword(),
+                        keyword.keywordPosition(),
+                        keyword.updatedAt()))
+            .orElse(KeywordMapper.toEntity(keyword));
+
+    KeywordEntity saved = keywordJpaRepository.save(entity);
+    return KeywordMapper.toDomain(saved);
+  }
+
+  @Override
+  @Transactional
+  public void deleteById(String keywordId) {
+    keywordJpaRepository.deleteById(keywordId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudController.java
@@ -1,0 +1,185 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.tempsotsusei.kotobanotane.application.keyword.KeywordService;
+import io.github.tempsotsusei.kotobanotane.application.keyword.KeywordUpdateCommand;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.keyword.Keyword;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * keyword テーブル向けの開発用 CRUD API を提供するコントローラ。
+ *
+ * <p>dev プロファイルでのみ有効とし、手動検証や Postman から利用する。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevKeywordCrudController {
+
+  private final KeywordService keywordService;
+  private final TimeProvider timeProvider;
+
+  public DevKeywordCrudController(KeywordService keywordService, TimeProvider timeProvider) {
+    this.keywordService = keywordService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** キーワード一覧を返す。 */
+  @GetMapping("/keywords")
+  @PreAuthorize("permitAll()")
+  public List<KeywordResponse> list() {
+    return keywordService.findAll().stream().map(this::toResponse).toList();
+  }
+
+  /** キーワード 1 件を取得する。 */
+  @GetMapping("/keyword/{keywordId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<KeywordResponse> get(@PathVariable String keywordId) {
+    return keywordService
+        .findById(keywordId)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** キーワードを新規作成する。 */
+  @PostMapping("/keyword")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<KeywordResponse> create(@Valid @RequestBody KeywordCreateRequest request) {
+    Keyword created =
+        keywordService.create(
+            request.chapterId(), request.keyword(), request.keywordPosition());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
+  }
+
+  /** キーワードを更新する。 */
+  @PutMapping("/keyword/{keywordId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<KeywordResponse> update(
+      @PathVariable String keywordId, @Valid @RequestBody KeywordUpdateRequest request) {
+    if (request.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    KeywordUpdateCommand command =
+        new KeywordUpdateCommand(
+            request.chapterIdSpecified(),
+            request.chapterId(),
+            request.keywordSpecified(),
+            request.keyword(),
+            request.keywordPositionSpecified(),
+            request.keywordPosition());
+
+    return keywordService
+        .update(keywordId, command)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** キーワードを削除する。 */
+  @DeleteMapping("/keyword/{keywordId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String keywordId) {
+    keywordService.delete(keywordId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private KeywordResponse toResponse(Keyword keyword) {
+    return new KeywordResponse(
+        keyword.keywordId(),
+        keyword.chapterId(),
+        keyword.keyword(),
+        keyword.keywordPosition(),
+        timeProvider.formatIso(keyword.createdAt()),
+        timeProvider.formatIso(keyword.updatedAt()));
+  }
+
+  /** キーワード作成リクエスト。 */
+  public record KeywordCreateRequest(
+      @NotBlank String chapterId, @NotBlank String keyword, @Min(1) int keywordPosition) {}
+
+  /** キーワード更新リクエスト。 */
+  public static class KeywordUpdateRequest {
+
+    private String chapterId;
+    private boolean chapterIdSpecified;
+    private String keyword;
+    private boolean keywordSpecified;
+    private Integer keywordPosition;
+    private boolean keywordPositionSpecified;
+
+    @JsonProperty("chapterId")
+    public void setChapterId(String chapterId) {
+      this.chapterId = chapterId;
+      this.chapterIdSpecified = true;
+    }
+
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+      this.keyword = keyword;
+      this.keywordSpecified = true;
+    }
+
+    @JsonProperty("keywordPosition")
+    public void setKeywordPosition(Integer keywordPosition) {
+      this.keywordPosition = keywordPosition;
+      this.keywordPositionSpecified = true;
+    }
+
+    public String chapterId() {
+      return chapterId;
+    }
+
+    public String keyword() {
+      return keyword;
+    }
+
+    public Integer keywordPosition() {
+      return keywordPosition;
+    }
+
+    public boolean chapterIdSpecified() {
+      return chapterIdSpecified;
+    }
+
+    public boolean keywordSpecified() {
+      return keywordSpecified;
+    }
+
+    public boolean keywordPositionSpecified() {
+      return keywordPositionSpecified;
+    }
+
+    boolean isEmpty() {
+      return !chapterIdSpecified && !keywordSpecified && !keywordPositionSpecified;
+    }
+  }
+
+  /** キーワードレスポンス DTO。 */
+  public record KeywordResponse(
+      String keywordId,
+      String chapterId,
+      String keyword,
+      int keywordPosition,
+      String createdAt,
+      String updatedAt) {}
+}

--- a/app/src/main/resources/db/migration/V5__create_keywords.sql
+++ b/app/src/main/resources/db/migration/V5__create_keywords.sql
@@ -1,0 +1,24 @@
+-- キーワード(keywords)テーブルを作成するマイグレーション
+CREATE TABLE IF NOT EXISTS keywords (
+    keyword_id VARCHAR(255) PRIMARY KEY,
+    chapter_id VARCHAR(255) NOT NULL,
+    keyword VARCHAR(255) NOT NULL,
+    keyword_position INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT fk_keywords_chapters FOREIGN KEY (chapter_id) REFERENCES chapters (chapter_id)
+);
+
+-- chapters への外部キー整合性と updated_at 自動更新のためのトリガー
+CREATE OR REPLACE FUNCTION set_keywords_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_keywords_updated_at ON keywords;
+CREATE TRIGGER trg_keywords_updated_at
+    BEFORE UPDATE ON keywords
+    FOR EACH ROW EXECUTE FUNCTION set_keywords_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudControllerTest.java
@@ -1,0 +1,162 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterService;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.application.user.UserService;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/** keyword CRUD API の動作を検証する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevKeywordCrudControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserService userService;
+  @Autowired private ThumbnailService thumbnailService;
+  @Autowired private StoryService storyService;
+  @Autowired private ChapterService chapterService;
+
+  private String baseChapterId;
+  private String secondaryChapterId;
+
+  @BeforeEach
+  void setUp() {
+    String auth0Id = "auth0|keyword-crud";
+    userService.findOrCreate(auth0Id);
+    Thumbnail thumbnail = thumbnailService.create("/path/to/keyword-thumb.png");
+    Story story = storyService.create(auth0Id, "Keyword Story", thumbnail.thumbnailId());
+    Chapter baseChapter = chapterService.create(story.storyId(), 1, "Base chapter");
+    Chapter secondaryChapter = chapterService.create(story.storyId(), 2, "Secondary chapter");
+    baseChapterId = baseChapter.chapterId();
+    secondaryChapterId = secondaryChapter.chapterId();
+  }
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("chapterId", baseChapterId);
+    createRequest.put("keyword", "puzzle");
+    createRequest.put("keywordPosition", 1);
+
+    // Create
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/keyword")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.keyword").value("puzzle"))
+            .andExpect(jsonPath("$.keywordPosition").value(1))
+            .andExpect(jsonPath("$.chapterId").value(baseChapterId))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String keywordId = created.get("keywordId").toString();
+
+    // List
+    mockMvc.perform(get("/api/crud/keywords")).andExpect(status().isOk());
+
+    // Get
+    mockMvc
+        .perform(get("/api/crud/keyword/" + keywordId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.keywordId").value(keywordId));
+
+    // Update
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("chapterId", secondaryChapterId);
+    updateRequest.put("keyword", "mystery");
+    updateRequest.put("keywordPosition", 3);
+
+    mockMvc
+        .perform(
+            put("/api/crud/keyword/" + keywordId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.keyword").value("mystery"))
+        .andExpect(jsonPath("$.keywordPosition").value(3))
+        .andExpect(jsonPath("$.chapterId").value(secondaryChapterId));
+
+    // Delete
+    mockMvc.perform(delete("/api/crud/keyword/" + keywordId)).andExpect(status().isNoContent());
+
+    // confirm deletion
+    mockMvc.perform(get("/api/crud/keyword/" + keywordId)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void returnsBadRequestWhenChapterDoesNotExist() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("chapterId", "non-existent-chapter");
+    createRequest.put("keyword", "alpha");
+    createRequest.put("keywordPosition", 1);
+
+    mockMvc
+        .perform(
+            post("/api/crud/keyword")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createRequest)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsBlankKeywordOnUpdate() throws Exception {
+    String keywordId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/keyword")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of(
+                                        "chapterId", baseChapterId,
+                                        "keyword", "initial",
+                                        "keywordPosition", 1))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("keywordId")
+            .asText();
+
+    mockMvc
+        .perform(
+            put("/api/crud/keyword/" + keywordId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("keyword", ""))))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
keywordsテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Keyword CRUD API テスト
- dev プロファイルで起動し、Chapter CRUD で作成した `chapterId` を把握しておく。
- キーワード新規作成 (POST /api/crud/keyword)
  - curl -X POST -H "Content-Type: application/json" -d '{"chapterId":"<chapterId>","keyword":"ことばのタネ","keywordPosition":1}' http://localhost:${APP_PORT:-8080}/api/crud/keyword
- キーワード一覧取得 (GET /api/crud/keywords)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/keywords
- キーワード詳細取得 (GET /api/crud/keyword/{keywordId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/keyword/<keywordId>
- キーワード更新 (PUT /api/crud/keyword/{keywordId})
  - curl -X PUT -H "Content-Type: application/json" -d '{"keyword":"更新後のタネ","keywordPosition":2}' http://localhost:${APP_PORT:-8080}/api/crud/keyword/<keywordId>
- キーワード削除 (DELETE /api/crud/keyword/{keywordId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/keyword/<keywordId>

### 関連Issue
close #19 