### PR TITLE
feat:feedbacksテーブルの実装

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackService.java
@@ -1,0 +1,124 @@
+package io.github.tempsotsusei.kotobanotane.application.feedback;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.FeedbackRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * feedbacks テーブルへの CRUD を担うアプリケーションサービス。
+ *
+ * <p>chapter の存在確認や本文バリデーションなどを担当する。
+ */
+@Service
+public class FeedbackService {
+
+  private final FeedbackRepository feedbackRepository;
+  private final ChapterRepository chapterRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+
+  public FeedbackService(
+      FeedbackRepository feedbackRepository,
+      ChapterRepository chapterRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider) {
+    this.feedbackRepository = feedbackRepository;
+    this.chapterRepository = chapterRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** すべてのフィードバックを返す。 */
+  public List<Feedback> findAll() {
+    return feedbackRepository.findAll();
+  }
+
+  /** フィードバック ID で取得する。 */
+  public Optional<Feedback> findById(String feedbackId) {
+    return feedbackRepository.findById(feedbackId);
+  }
+
+  /**
+   * フィードバックを新規登録する。
+   *
+   * @param chapterId 紐付ける章 ID
+   * @param feedbackText 本文
+   * @return 登録結果
+   */
+  @Transactional
+  public Feedback create(String chapterId, String feedbackText) {
+    ensureChapterExists(chapterId);
+    ensureFeedbackText(feedbackText);
+
+    Instant now = timeProvider.nowInstant();
+    Feedback feedback =
+        new Feedback(uuidGeneratorService.generateV7(), chapterId, feedbackText, now, now);
+    return feedbackRepository.save(feedback);
+  }
+
+  /**
+   * フィードバックを更新する。
+   *
+   * @param feedbackId フィードバック ID
+   * @param command 差分コマンド
+   * @return 更新結果（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<Feedback> update(String feedbackId, FeedbackUpdateCommand command) {
+    return feedbackRepository
+        .findById(feedbackId)
+        .map(existing -> applyUpdate(existing, command))
+        .map(feedbackRepository::save);
+  }
+
+  /** フィードバックを削除する。 */
+  @Transactional
+  public void delete(String feedbackId) {
+    feedbackRepository.deleteById(feedbackId);
+  }
+
+  private Feedback applyUpdate(Feedback existing, FeedbackUpdateCommand command) {
+    String nextChapterId = existing.chapterId();
+    if (command.chapterIdSpecified()) {
+      String candidate = command.chapterId();
+      if (!StringUtils.hasText(candidate)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterId must not be blank");
+      }
+      ensureChapterExists(candidate);
+      nextChapterId = candidate;
+    }
+
+    String nextFeedback = existing.feedback();
+    if (command.feedbackSpecified()) {
+      ensureFeedbackText(command.feedback());
+      nextFeedback = command.feedback();
+    }
+
+    Instant updatedAt = timeProvider.nowInstant();
+    return new Feedback(existing.feedbackId(), nextChapterId, nextFeedback, existing.createdAt(), updatedAt);
+  }
+
+  private void ensureChapterExists(String chapterId) {
+    boolean exists = chapterRepository.findById(chapterId).isPresent();
+    if (!exists) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterId does not exist: " + chapterId);
+    }
+  }
+
+  private void ensureFeedbackText(String feedbackText) {
+    if (!StringUtils.hasText(feedbackText)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "feedback must not be blank");
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackUpdateCommand.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackUpdateCommand.java
@@ -1,0 +1,12 @@
+package io.github.tempsotsusei.kotobanotane.application.feedback;
+
+/**
+ * フィードバック更新時の差分情報を保持するコマンド。
+ *
+ * @param chapterIdSpecified chapterId がリクエストに含まれていたか
+ * @param chapterId 更新後の章 ID
+ * @param feedbackSpecified feedback が含まれていたか
+ * @param feedback 更新後の本文
+ */
+public record FeedbackUpdateCommand(
+    boolean chapterIdSpecified, String chapterId, boolean feedbackSpecified, String feedback) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/Feedback.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/Feedback.java
@@ -1,0 +1,15 @@
+package io.github.tempsotsusei.kotobanotane.domain.feedback;
+
+import java.time.Instant;
+
+/**
+ * フィードバック(feedback)情報を表すドメインオブジェクト。
+ *
+ * <p>紐付く章 ID・本文・作成/更新日時などを集約する。
+ */
+public record Feedback(
+    String feedbackId,
+    String chapterId,
+    String feedback,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/FeedbackRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/FeedbackRepository.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.feedback;
+
+import java.util.List;
+import java.util.Optional;
+
+/** feedbacks テーブルへアクセスするためのリポジトリ。 */
+public interface FeedbackRepository {
+
+  Optional<Feedback> findById(String feedbackId);
+
+  List<Feedback> findAll();
+
+  Feedback save(Feedback feedback);
+
+  void deleteById(String feedbackId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackEntity.java
@@ -1,0 +1,83 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** feedbacks テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "feedbacks")
+public class FeedbackEntity {
+
+  /** フィードバック ID。 */
+  @Id
+  @Column(name = "feedback_id", length = 255, nullable = false)
+  private String feedbackId;
+
+  /** 紐付く章 ID。 */
+  @Column(name = "chapter_id", length = 255, nullable = false)
+  private String chapterId;
+
+  /**
+   * フィードバック本文。
+   *
+   * <p>OID ではなく TEXT を利用したいので columnDefinition を指定している。
+   */
+  @Column(name = "feedback", nullable = false, columnDefinition = "TEXT")
+  private String feedback;
+
+  /** 作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  /** 更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  /** JPA が利用するデフォルトコンストラクタ。 */
+  protected FeedbackEntity() {}
+
+  public FeedbackEntity(
+      String feedbackId, String chapterId, String feedback, Instant createdAt, Instant updatedAt) {
+    this.feedbackId = feedbackId;
+    this.chapterId = chapterId;
+    this.feedback = feedback;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getFeedbackId() {
+    return feedbackId;
+  }
+
+  public String getChapterId() {
+    return chapterId;
+  }
+
+  public String getFeedback() {
+    return feedback;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
+   * 章 ID / 本文を更新し、更新日時を反映する。
+   *
+   * @param newChapterId 更新後の章 ID
+   * @param newFeedback 更新後の本文
+   * @param newUpdatedAt 更新日時
+   */
+  public void updateDetails(String newChapterId, String newFeedback, Instant newUpdatedAt) {
+    this.chapterId = newChapterId;
+    this.feedback = newFeedback;
+    this.updatedAt = newUpdatedAt;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackJpaRepository.java
@@ -1,0 +1,6 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** feedbacks テーブルへアクセスする Spring Data JPA リポジトリ。 */
+public interface FeedbackJpaRepository extends JpaRepository<FeedbackEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackMapper.java
@@ -1,0 +1,34 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback;
+
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import java.time.Instant;
+
+/** feedback ドメイン ↔ エンティティ変換を行うユーティリティ。 */
+public final class FeedbackMapper {
+
+  private FeedbackMapper() {}
+
+  public static Feedback toDomain(FeedbackEntity entity) {
+    return new Feedback(
+        entity.getFeedbackId(),
+        entity.getChapterId(),
+        entity.getFeedback(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  public static FeedbackEntity toEntity(Feedback feedback) {
+    return new FeedbackEntity(
+        feedback.feedbackId(),
+        feedback.chapterId(),
+        feedback.feedback(),
+        feedback.createdAt(),
+        feedback.updatedAt());
+  }
+
+  public static FeedbackEntity toEntityForUpdate(
+      FeedbackEntity entity, String chapterId, String feedback, Instant updatedAt) {
+    entity.updateDetails(chapterId, feedback, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackRepositoryImpl.java
@@ -1,0 +1,52 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback;
+
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.FeedbackRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** FeedbackRepository を JPA で実現する実装クラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class FeedbackRepositoryImpl implements FeedbackRepository {
+
+  private final FeedbackJpaRepository feedbackJpaRepository;
+
+  public FeedbackRepositoryImpl(FeedbackJpaRepository feedbackJpaRepository) {
+    this.feedbackJpaRepository = feedbackJpaRepository;
+  }
+
+  @Override
+  public Optional<Feedback> findById(String feedbackId) {
+    return feedbackJpaRepository.findById(feedbackId).map(FeedbackMapper::toDomain);
+  }
+
+  @Override
+  public List<Feedback> findAll() {
+    return feedbackJpaRepository.findAll().stream().map(FeedbackMapper::toDomain).toList();
+  }
+
+  @Override
+  @Transactional
+  public Feedback save(Feedback feedback) {
+    FeedbackEntity entity =
+        feedbackJpaRepository
+            .findById(feedback.feedbackId())
+            .map(
+                existing ->
+                    FeedbackMapper.toEntityForUpdate(
+                        existing, feedback.chapterId(), feedback.feedback(), feedback.updatedAt()))
+            .orElse(FeedbackMapper.toEntity(feedback));
+
+    FeedbackEntity saved = feedbackJpaRepository.save(entity);
+    return FeedbackMapper.toDomain(saved);
+  }
+
+  @Override
+  @Transactional
+  public void deleteById(String feedbackId) {
+    feedbackJpaRepository.deleteById(feedbackId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudController.java
@@ -1,0 +1,154 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.tempsotsusei.kotobanotane.application.feedback.FeedbackService;
+import io.github.tempsotsusei.kotobanotane.application.feedback.FeedbackUpdateCommand;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * フィードバック(feedbacks)向けの開発用 CRUD API を提供するコントローラ。
+ *
+ * <p>dev プロファイルで有効化し、Postman や curl による検証を容易にする。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevFeedbackCrudController {
+
+  private final FeedbackService feedbackService;
+  private final TimeProvider timeProvider;
+
+  public DevFeedbackCrudController(FeedbackService feedbackService, TimeProvider timeProvider) {
+    this.feedbackService = feedbackService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** フィードバック一覧を返す。 */
+  @GetMapping("/feedbacks")
+  @PreAuthorize("permitAll()")
+  public List<FeedbackResponse> list() {
+    return feedbackService.findAll().stream().map(this::toResponse).toList();
+  }
+
+  /** 指定したフィードバックを取得する。 */
+  @GetMapping("/feedback/{feedbackId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<FeedbackResponse> get(@PathVariable String feedbackId) {
+    return feedbackService
+        .findById(feedbackId)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** フィードバックを新規作成する。 */
+  @PostMapping("/feedback")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<FeedbackResponse> create(@Valid @RequestBody FeedbackCreateRequest request) {
+    Feedback created = feedbackService.create(request.chapterId(), request.feedback());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
+  }
+
+  /** フィードバックを更新する。 */
+  @PutMapping("/feedback/{feedbackId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<FeedbackResponse> update(
+      @PathVariable String feedbackId, @Valid @RequestBody FeedbackUpdateRequest request) {
+    if (request.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    FeedbackUpdateCommand command =
+        new FeedbackUpdateCommand(
+            request.chapterIdSpecified(), request.chapterId(), request.feedbackSpecified(), request.feedback());
+
+    return feedbackService
+        .update(feedbackId, command)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** フィードバックを削除する。 */
+  @DeleteMapping("/feedback/{feedbackId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String feedbackId) {
+    feedbackService.delete(feedbackId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private FeedbackResponse toResponse(Feedback feedback) {
+    return new FeedbackResponse(
+        feedback.feedbackId(),
+        feedback.chapterId(),
+        feedback.feedback(),
+        timeProvider.formatIso(feedback.createdAt()),
+        timeProvider.formatIso(feedback.updatedAt()));
+  }
+
+  /** フィードバック作成リクエスト。 */
+  public record FeedbackCreateRequest(@NotBlank String chapterId, @NotBlank String feedback) {}
+
+  /** フィードバック更新リクエスト。 */
+  public static class FeedbackUpdateRequest {
+
+    private String chapterId;
+    private boolean chapterIdSpecified;
+    private String feedback;
+    private boolean feedbackSpecified;
+
+    @JsonProperty("chapterId")
+    public void setChapterId(String chapterId) {
+      this.chapterId = chapterId;
+      this.chapterIdSpecified = true;
+    }
+
+    @JsonProperty("feedback")
+    public void setFeedback(String feedback) {
+      this.feedback = feedback;
+      this.feedbackSpecified = true;
+    }
+
+    public String chapterId() {
+      return chapterId;
+    }
+
+    public String feedback() {
+      return feedback;
+    }
+
+    public boolean chapterIdSpecified() {
+      return chapterIdSpecified;
+    }
+
+    public boolean feedbackSpecified() {
+      return feedbackSpecified;
+    }
+
+    boolean isEmpty() {
+      return !chapterIdSpecified && !feedbackSpecified;
+    }
+  }
+
+  /** フィードバックレスポンス DTO。 */
+  public record FeedbackResponse(
+      String feedbackId, String chapterId, String feedback, String createdAt, String updatedAt) {}
+}

--- a/app/src/main/resources/db/migration/V6__create_feedbacks.sql
+++ b/app/src/main/resources/db/migration/V6__create_feedbacks.sql
@@ -1,0 +1,23 @@
+-- フィードバック(feedbacks)テーブルを作成するマイグレーション
+CREATE TABLE IF NOT EXISTS feedbacks (
+    feedback_id VARCHAR(255) PRIMARY KEY,
+    chapter_id VARCHAR(255) NOT NULL,
+    feedback TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT fk_feedbacks_chapters FOREIGN KEY (chapter_id) REFERENCES chapters (chapter_id)
+);
+
+-- chapters 参照を保ちつつ updated_at を自動更新するトリガー
+CREATE OR REPLACE FUNCTION set_feedbacks_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_feedbacks_updated_at ON feedbacks;
+CREATE TRIGGER trg_feedbacks_updated_at
+    BEFORE UPDATE ON feedbacks
+    FOR EACH ROW EXECUTE FUNCTION set_feedbacks_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudControllerTest.java
@@ -1,0 +1,142 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterService;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.application.user.UserService;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/** feedback CRUD API の挙動を確認する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevFeedbackCrudControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private UserService userService;
+  @Autowired private ThumbnailService thumbnailService;
+  @Autowired private StoryService storyService;
+  @Autowired private ChapterService chapterService;
+
+  private String chapterId;
+
+  @BeforeEach
+  void setUp() {
+    String auth0Id = "auth0|feedback-crud";
+    userService.findOrCreate(auth0Id);
+    Thumbnail thumbnail = thumbnailService.create("/path/to/feedback-thumb.png");
+    Story story = storyService.create(auth0Id, "Feedback Story", thumbnail.thumbnailId());
+    Chapter chapter = chapterService.create(story.storyId(), 1, "Feedback chapter");
+    chapterId = chapter.chapterId();
+  }
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("chapterId", chapterId);
+    createRequest.put("feedback", "Great job!");
+
+    // Create
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/feedback")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.feedback").value("Great job!"))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String feedbackId = created.get("feedbackId").toString();
+
+    // List
+    mockMvc.perform(get("/api/crud/feedbacks")).andExpect(status().isOk());
+
+    // Get
+    mockMvc
+        .perform(get("/api/crud/feedback/" + feedbackId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.feedbackId").value(feedbackId));
+
+    // Update
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("feedback", "Needs improvement");
+
+    mockMvc
+        .perform(
+            put("/api/crud/feedback/" + feedbackId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.feedback").value("Needs improvement"));
+
+    // Delete
+    mockMvc.perform(delete("/api/crud/feedback/" + feedbackId)).andExpect(status().isNoContent());
+  }
+
+  @Test
+  void returnsBadRequestWhenChapterDoesNotExist() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/crud/feedback")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of("chapterId", "non-existent", "feedback", "hello"))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsBlankFeedbackOnUpdate() throws Exception {
+    String feedbackId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/feedback")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of("chapterId", chapterId, "feedback", "initial text"))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("feedbackId")
+            .asText();
+
+    mockMvc
+        .perform(
+            put("/api/crud/feedback/" + feedbackId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("feedback", ""))))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
feedbacksテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Feedback CRUD API テスト
- dev プロファイルで起動し、Chapter CRUD で作成した `chapterId` を利用できることを確認する。
- フィードバック新規作成 (POST /api/crud/feedback)
  - curl -X POST -H "Content-Type: application/json" -d '{"chapterId":"<chapterId>","feedback":"気に入った点など"}' http://localhost:${APP_PORT:-8080}/api/crud/feedback
- フィードバック一覧取得 (GET /api/crud/feedbacks)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/feedbacks
- フィードバック詳細取得 (GET /api/crud/feedback/{feedbackId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/feedback/<feedbackId>
- フィードバック更新 (PUT /api/crud/feedback/{feedbackId})
  - curl -X PUT -H "Content-Type: application/json" -d '{"feedback":"改善要望など"}' http://localhost:${APP_PORT:-8080}/api/crud/feedback/<feedbackId>
- フィードバック削除 (DELETE /api/crud/feedback/{feedbackId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/feedback/<feedbackId>

### 関連Issue
close #20 