### PR TITLE
feat:thumbnail_templatesテーブルの実装

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackService.java
@@ -105,7 +105,8 @@ public class FeedbackService {
     }
 
     Instant updatedAt = timeProvider.nowInstant();
-    return new Feedback(existing.feedbackId(), nextChapterId, nextFeedback, existing.createdAt(), updatedAt);
+    return new Feedback(
+        existing.feedbackId(), nextChapterId, nextFeedback, existing.createdAt(), updatedAt);
   }
 
   private void ensureChapterExists(String chapterId) {

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateService.java
@@ -1,0 +1,108 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate;
+
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplateRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** thumbnail_templates テーブルへの CRUD を担うアプリケーションサービス。 */
+@Service
+public class ThumbnailTemplateService {
+
+  private final ThumbnailTemplateRepository thumbnailTemplateRepository;
+  private final ThumbnailRepository thumbnailRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+
+  public ThumbnailTemplateService(
+      ThumbnailTemplateRepository thumbnailTemplateRepository,
+      ThumbnailRepository thumbnailRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider) {
+    this.thumbnailTemplateRepository = thumbnailTemplateRepository;
+    this.thumbnailRepository = thumbnailRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** すべてのテンプレートを取得する。 */
+  public List<ThumbnailTemplate> findAll() {
+    return thumbnailTemplateRepository.findAll();
+  }
+
+  /** テンプレート ID で取得する。 */
+  public Optional<ThumbnailTemplate> findById(String templateId) {
+    return thumbnailTemplateRepository.findById(templateId);
+  }
+
+  /**
+   * テンプレートを新規作成する。
+   *
+   * @param thumbnailId 紐付けるサムネイル ID
+   * @return 作成したテンプレート
+   */
+  @Transactional
+  public ThumbnailTemplate create(String thumbnailId) {
+    ensureThumbnailExists(thumbnailId);
+    Instant now = timeProvider.nowInstant();
+    ThumbnailTemplate template =
+        new ThumbnailTemplate(uuidGeneratorService.generateV7(), thumbnailId, now, now);
+    return thumbnailTemplateRepository.save(template);
+  }
+
+  /**
+   * テンプレートを更新する。
+   *
+   * @param templateId テンプレート ID
+   * @param command 更新コマンド
+   * @return 更新後テンプレート（存在しない場合は空）
+   */
+  @Transactional
+  public Optional<ThumbnailTemplate> update(
+      String templateId, ThumbnailTemplateUpdateCommand command) {
+    return thumbnailTemplateRepository
+        .findById(templateId)
+        .map(existing -> applyUpdate(existing, command))
+        .map(thumbnailTemplateRepository::save);
+  }
+
+  /** テンプレートを削除する。 */
+  @Transactional
+  public void delete(String templateId) {
+    thumbnailTemplateRepository.deleteById(templateId);
+  }
+
+  private ThumbnailTemplate applyUpdate(
+      ThumbnailTemplate existing, ThumbnailTemplateUpdateCommand command) {
+    String nextThumbnailId = existing.thumbnailId();
+    if (command.thumbnailIdSpecified()) {
+      String candidate = command.thumbnailId();
+      if (!StringUtils.hasText(candidate)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "thumbnailId must not be blank");
+      }
+      ensureThumbnailExists(candidate);
+      nextThumbnailId = candidate;
+    }
+
+    Instant updatedAt = timeProvider.nowInstant();
+    return new ThumbnailTemplate(
+        existing.thumbnailTemplateId(), nextThumbnailId, existing.createdAt(), updatedAt);
+  }
+
+  private void ensureThumbnailExists(String thumbnailId) {
+    boolean exists = thumbnailRepository.findById(thumbnailId).isPresent();
+    if (!exists) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "thumbnailId does not exist: " + thumbnailId);
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateUpdateCommand.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateUpdateCommand.java
@@ -1,0 +1,9 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate;
+
+/**
+ * サムネイルテンプレート更新時に利用するコマンド。
+ *
+ * @param thumbnailIdSpecified thumbnailId がリクエストに含まれていたか
+ * @param thumbnailId 更新後のサムネイル ID
+ */
+public record ThumbnailTemplateUpdateCommand(boolean thumbnailIdSpecified, String thumbnailId) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/Feedback.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/Feedback.java
@@ -8,8 +8,4 @@ import java.time.Instant;
  * <p>紐付く章 ID・本文・作成/更新日時などを集約する。
  */
 public record Feedback(
-    String feedbackId,
-    String chapterId,
-    String feedback,
-    Instant createdAt,
-    Instant updatedAt) {}
+    String feedbackId, String chapterId, String feedback, Instant createdAt, Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnailtemplate/ThumbnailTemplate.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnailtemplate/ThumbnailTemplate.java
@@ -1,0 +1,11 @@
+package io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate;
+
+import java.time.Instant;
+
+/**
+ * サムネイルテンプレート情報を保持するドメインオブジェクト。
+ *
+ * <p>テンプレート自体の ID と紐付くサムネイル ID、作成・更新日時を取り扱う。
+ */
+public record ThumbnailTemplate(
+    String thumbnailTemplateId, String thumbnailId, Instant createdAt, Instant updatedAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnailtemplate/ThumbnailTemplateRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnailtemplate/ThumbnailTemplateRepository.java
@@ -1,0 +1,16 @@
+package io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+/** thumbnail_templates テーブルへアクセスするリポジトリ。 */
+public interface ThumbnailTemplateRepository {
+
+  Optional<ThumbnailTemplate> findById(String thumbnailTemplateId);
+
+  List<ThumbnailTemplate> findAll();
+
+  ThumbnailTemplate save(ThumbnailTemplate template);
+
+  void deleteById(String thumbnailTemplateId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordEntity.java
@@ -1,98 +1,96 @@
 package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.keyword;
 
-import java.time.Instant;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
 
 /** keywords テーブルに対応する JPA エンティティ。 */
 @Entity
 @Table(name = "keywords")
 public class KeywordEntity {
 
-	/** キーワード ID。 */
-	@Id
-	@Column(name = "keyword_id", length = 255, nullable = false)
-	private String keywordId;
+  /** キーワード ID。 */
+  @Id
+  @Column(name = "keyword_id", length = 255, nullable = false)
+  private String keywordId;
 
-	/** 紐付く章 ID。 */
-	@Column(name = "chapter_id", length = 255, nullable = false)
-	private String chapterId;
+  /** 紐付く章 ID。 */
+  @Column(name = "chapter_id", length = 255, nullable = false)
+  private String chapterId;
 
-	/** キーワード文字列。 */
-	@Column(name = "keyword", length = 255, nullable = false)
-	private String keyword;
+  /** キーワード文字列。 */
+  @Column(name = "keyword", length = 255, nullable = false)
+  private String keyword;
 
-	/** キーワードの出現文字数。 */
-	@Column(name = "keyword_position", nullable = false)
-	private int keywordPosition;
+  /** キーワードの出現文字数。 */
+  @Column(name = "keyword_position", nullable = false)
+  private int keywordPosition;
 
-	/** 作成日時。 */
-	@Column(name = "created_at", nullable = false)
-	private Instant createdAt;
+  /** 作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
 
-	/** 更新日時。 */
-	@Column(name = "updated_at")
-	private Instant updatedAt;
+  /** 更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
 
-	/** JPA が利用するデフォルトコンストラクタ。 */
-	protected KeywordEntity() {
-	}
+  /** JPA が利用するデフォルトコンストラクタ。 */
+  protected KeywordEntity() {}
 
-	public KeywordEntity(
-			String keywordId,
-			String chapterId,
-			String keyword,
-			int keywordPosition,
-			Instant createdAt,
-			Instant updatedAt) {
-		this.keywordId = keywordId;
-		this.chapterId = chapterId;
-		this.keyword = keyword;
-		this.keywordPosition = keywordPosition;
-		this.createdAt = createdAt;
-		this.updatedAt = updatedAt;
-	}
+  public KeywordEntity(
+      String keywordId,
+      String chapterId,
+      String keyword,
+      int keywordPosition,
+      Instant createdAt,
+      Instant updatedAt) {
+    this.keywordId = keywordId;
+    this.chapterId = chapterId;
+    this.keyword = keyword;
+    this.keywordPosition = keywordPosition;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
 
-	public String getKeywordId() {
-		return keywordId;
-	}
+  public String getKeywordId() {
+    return keywordId;
+  }
 
-	public String getChapterId() {
-		return chapterId;
-	}
+  public String getChapterId() {
+    return chapterId;
+  }
 
-	public String getKeyword() {
-		return keyword;
-	}
+  public String getKeyword() {
+    return keyword;
+  }
 
-	public int getKeywordPosition() {
-		return keywordPosition;
-	}
+  public int getKeywordPosition() {
+    return keywordPosition;
+  }
 
-	public Instant getCreatedAt() {
-		return createdAt;
-	}
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
 
-	public Instant getUpdatedAt() {
-		return updatedAt;
-	}
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
 
-	/**
-	 * 章 ID・キーワード本文・表示順を変更し、更新日時を反映する。
-	 *
-	 * @param newChapterId       更新後の章 ID
-	 * @param newKeyword         更新後のキーワード本文
-	 * @param newKeywordPosition 更新後の表示順
-	 * @param newUpdatedAt       更新日時
-	 */
-	public void updateDetails(
-			String newChapterId, String newKeyword, int newKeywordPosition, Instant newUpdatedAt) {
-		this.chapterId = newChapterId;
-		this.keyword = newKeyword;
-		this.keywordPosition = newKeywordPosition;
-		this.updatedAt = newUpdatedAt;
-	}
+  /**
+   * 章 ID・キーワード本文・表示順を変更し、更新日時を反映する。
+   *
+   * @param newChapterId 更新後の章 ID
+   * @param newKeyword 更新後のキーワード本文
+   * @param newKeywordPosition 更新後の表示順
+   * @param newUpdatedAt 更新日時
+   */
+  public void updateDetails(
+      String newChapterId, String newKeyword, int newKeywordPosition, Instant newUpdatedAt) {
+    this.chapterId = newChapterId;
+    this.keyword = newKeyword;
+    this.keywordPosition = newKeywordPosition;
+    this.updatedAt = newUpdatedAt;
+  }
 }

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/keyword/KeywordMapper.java
@@ -29,7 +29,11 @@ public final class KeywordMapper {
   }
 
   public static KeywordEntity toEntityForUpdate(
-      KeywordEntity entity, String chapterId, String keywordValue, int keywordPosition, Instant updatedAt) {
+      KeywordEntity entity,
+      String chapterId,
+      String keywordValue,
+      int keywordPosition,
+      Instant updatedAt) {
     entity.updateDetails(chapterId, keywordValue, keywordPosition, updatedAt);
     return entity;
   }

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateEntity.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateEntity.java
@@ -1,0 +1,68 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnailtemplate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** thumbnail_templates テーブルに対応する JPA エンティティ。 */
+@Entity
+@Table(name = "thumbnail_templates")
+public class ThumbnailTemplateEntity {
+
+  /** テンプレート ID。 */
+  @Id
+  @Column(name = "thumbnail_template_id", length = 255, nullable = false)
+  private String thumbnailTemplateId;
+
+  /** 紐付くサムネイル ID。 */
+  @Column(name = "thumbnail_id", length = 255, nullable = false)
+  private String thumbnailId;
+
+  /** 作成日時。 */
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  /** 更新日時。 */
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  /** JPA が利用するデフォルトコンストラクタ。 */
+  protected ThumbnailTemplateEntity() {}
+
+  public ThumbnailTemplateEntity(
+      String thumbnailTemplateId, String thumbnailId, Instant createdAt, Instant updatedAt) {
+    this.thumbnailTemplateId = thumbnailTemplateId;
+    this.thumbnailId = thumbnailId;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public String getThumbnailTemplateId() {
+    return thumbnailTemplateId;
+  }
+
+  public String getThumbnailId() {
+    return thumbnailId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  /**
+   * サムネイル ID を更新し、更新日時を反映する。
+   *
+   * @param newThumbnailId 更新後のサムネイル ID
+   * @param newUpdatedAt 更新日時
+   */
+  public void updateThumbnailId(String newThumbnailId, Instant newUpdatedAt) {
+    this.thumbnailId = newThumbnailId;
+    this.updatedAt = newUpdatedAt;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateJpaRepository.java
@@ -1,0 +1,7 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnailtemplate;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** thumbnail_templates テーブルへアクセスする Spring Data JPA リポジトリ。 */
+public interface ThumbnailTemplateJpaRepository
+    extends JpaRepository<ThumbnailTemplateEntity, String> {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateMapper.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateMapper.java
@@ -1,0 +1,32 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnailtemplate;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import java.time.Instant;
+
+/** thumbnail template のドメイン ↔ エンティティ変換を行うユーティリティ。 */
+public final class ThumbnailTemplateMapper {
+
+  private ThumbnailTemplateMapper() {}
+
+  public static ThumbnailTemplate toDomain(ThumbnailTemplateEntity entity) {
+    return new ThumbnailTemplate(
+        entity.getThumbnailTemplateId(),
+        entity.getThumbnailId(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  public static ThumbnailTemplateEntity toEntity(ThumbnailTemplate template) {
+    return new ThumbnailTemplateEntity(
+        template.thumbnailTemplateId(),
+        template.thumbnailId(),
+        template.createdAt(),
+        template.updatedAt());
+  }
+
+  public static ThumbnailTemplateEntity toEntityForUpdate(
+      ThumbnailTemplateEntity entity, String thumbnailId, Instant updatedAt) {
+    entity.updateThumbnailId(thumbnailId, updatedAt);
+    return entity;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnailtemplate/ThumbnailTemplateRepositoryImpl.java
@@ -1,0 +1,57 @@
+package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnailtemplate;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplateRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/** ThumbnailTemplateRepository を JPA で実現する実装クラス。 */
+@Repository
+@Transactional(readOnly = true)
+public class ThumbnailTemplateRepositoryImpl implements ThumbnailTemplateRepository {
+
+  private final ThumbnailTemplateJpaRepository thumbnailTemplateJpaRepository;
+
+  public ThumbnailTemplateRepositoryImpl(
+      ThumbnailTemplateJpaRepository thumbnailTemplateJpaRepository) {
+    this.thumbnailTemplateJpaRepository = thumbnailTemplateJpaRepository;
+  }
+
+  @Override
+  public Optional<ThumbnailTemplate> findById(String thumbnailTemplateId) {
+    return thumbnailTemplateJpaRepository
+        .findById(thumbnailTemplateId)
+        .map(ThumbnailTemplateMapper::toDomain);
+  }
+
+  @Override
+  public List<ThumbnailTemplate> findAll() {
+    return thumbnailTemplateJpaRepository.findAll().stream()
+        .map(ThumbnailTemplateMapper::toDomain)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public ThumbnailTemplate save(ThumbnailTemplate template) {
+    ThumbnailTemplateEntity entity =
+        thumbnailTemplateJpaRepository
+            .findById(template.thumbnailTemplateId())
+            .map(
+                existing ->
+                    ThumbnailTemplateMapper.toEntityForUpdate(
+                        existing, template.thumbnailId(), template.updatedAt()))
+            .orElse(ThumbnailTemplateMapper.toEntity(template));
+
+    ThumbnailTemplateEntity saved = thumbnailTemplateJpaRepository.save(entity);
+    return ThumbnailTemplateMapper.toDomain(saved);
+  }
+
+  @Override
+  @Transactional
+  public void deleteById(String thumbnailTemplateId) {
+    thumbnailTemplateJpaRepository.deleteById(thumbnailTemplateId);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevFeedbackCrudController.java
@@ -62,7 +62,8 @@ public class DevFeedbackCrudController {
   /** フィードバックを新規作成する。 */
   @PostMapping("/feedback")
   @PreAuthorize("permitAll()")
-  public ResponseEntity<FeedbackResponse> create(@Valid @RequestBody FeedbackCreateRequest request) {
+  public ResponseEntity<FeedbackResponse> create(
+      @Valid @RequestBody FeedbackCreateRequest request) {
     Feedback created = feedbackService.create(request.chapterId(), request.feedback());
     return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
   }
@@ -78,7 +79,10 @@ public class DevFeedbackCrudController {
 
     FeedbackUpdateCommand command =
         new FeedbackUpdateCommand(
-            request.chapterIdSpecified(), request.chapterId(), request.feedbackSpecified(), request.feedback());
+            request.chapterIdSpecified(),
+            request.chapterId(),
+            request.feedbackSpecified(),
+            request.feedback());
 
     return feedbackService
         .update(feedbackId, command)

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudController.java
@@ -65,8 +65,7 @@ public class DevKeywordCrudController {
   @PreAuthorize("permitAll()")
   public ResponseEntity<KeywordResponse> create(@Valid @RequestBody KeywordCreateRequest request) {
     Keyword created =
-        keywordService.create(
-            request.chapterId(), request.keyword(), request.keywordPosition());
+        keywordService.create(request.chapterId(), request.keyword(), request.keywordPosition());
     return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
   }
 

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailTemplateCrudController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailTemplateCrudController.java
@@ -1,0 +1,139 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateUpdateCommand;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * サムネイルテンプレート向けの開発用 CRUD API。
+ *
+ * <p>dev プロファイルのみで動作し、Postman や curl での検証を容易にする。
+ */
+@RestController
+@RequestMapping("/api/crud")
+@Profile("dev")
+@Validated
+public class DevThumbnailTemplateCrudController {
+
+  private final ThumbnailTemplateService thumbnailTemplateService;
+  private final TimeProvider timeProvider;
+
+  public DevThumbnailTemplateCrudController(
+      ThumbnailTemplateService thumbnailTemplateService, TimeProvider timeProvider) {
+    this.thumbnailTemplateService = thumbnailTemplateService;
+    this.timeProvider = timeProvider;
+  }
+
+  /** テンプレート一覧を返す。 */
+  @GetMapping("/thumbnail_templates")
+  @PreAuthorize("permitAll()")
+  public List<ThumbnailTemplateResponse> list() {
+    return thumbnailTemplateService.findAll().stream().map(this::toResponse).toList();
+  }
+
+  /** テンプレートを 1 件取得する。 */
+  @GetMapping("/thumbnail_template/{thumbnailTemplateId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailTemplateResponse> get(@PathVariable String thumbnailTemplateId) {
+    return thumbnailTemplateService
+        .findById(thumbnailTemplateId)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** テンプレートを新規作成する。 */
+  @PostMapping("/thumbnail_template")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailTemplateResponse> create(
+      @Valid @RequestBody ThumbnailTemplateCreateRequest request) {
+    ThumbnailTemplate created = thumbnailTemplateService.create(request.thumbnailId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(created));
+  }
+
+  /** テンプレートを更新する。 */
+  @PutMapping("/thumbnail_template/{thumbnailTemplateId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<ThumbnailTemplateResponse> update(
+      @PathVariable String thumbnailTemplateId,
+      @Valid @RequestBody ThumbnailTemplateUpdateRequest request) {
+    if (request.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    ThumbnailTemplateUpdateCommand command =
+        new ThumbnailTemplateUpdateCommand(request.thumbnailIdSpecified(), request.thumbnailId());
+
+    return thumbnailTemplateService
+        .update(thumbnailTemplateId, command)
+        .map(this::toResponse)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /** テンプレートを削除する。 */
+  @DeleteMapping("/thumbnail_template/{thumbnailTemplateId}")
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<Void> delete(@PathVariable String thumbnailTemplateId) {
+    thumbnailTemplateService.delete(thumbnailTemplateId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private ThumbnailTemplateResponse toResponse(ThumbnailTemplate template) {
+    return new ThumbnailTemplateResponse(
+        template.thumbnailTemplateId(),
+        template.thumbnailId(),
+        timeProvider.formatIso(template.createdAt()),
+        timeProvider.formatIso(template.updatedAt()));
+  }
+
+  /** 作成リクエスト。 */
+  public record ThumbnailTemplateCreateRequest(@NotBlank String thumbnailId) {}
+
+  /** 更新リクエスト。 */
+  public static class ThumbnailTemplateUpdateRequest {
+
+    private String thumbnailId;
+    private boolean thumbnailIdSpecified;
+
+    @JsonProperty("thumbnailId")
+    public void setThumbnailId(String thumbnailId) {
+      this.thumbnailId = thumbnailId;
+      this.thumbnailIdSpecified = true;
+    }
+
+    public String thumbnailId() {
+      return thumbnailId;
+    }
+
+    public boolean thumbnailIdSpecified() {
+      return thumbnailIdSpecified;
+    }
+
+    boolean isEmpty() {
+      return !thumbnailIdSpecified;
+    }
+  }
+
+  /** レスポンス DTO。 */
+  public record ThumbnailTemplateResponse(
+      String thumbnailTemplateId, String thumbnailId, String createdAt, String updatedAt) {}
+}

--- a/app/src/main/resources/db/migration/V7__create_thumbnail_templates.sql
+++ b/app/src/main/resources/db/migration/V7__create_thumbnail_templates.sql
@@ -1,0 +1,22 @@
+-- サムネイルテンプレート(thumbnail_templates)テーブルを作成するマイグレーション
+CREATE TABLE IF NOT EXISTS thumbnail_templates (
+    thumbnail_template_id VARCHAR(255) PRIMARY KEY,
+    thumbnail_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT fk_thumbnail_templates_thumbnails FOREIGN KEY (thumbnail_id) REFERENCES thumbnails (thumbnail_id)
+);
+
+-- thumbnails への参照を保ちつつ updated_at を自動更新するトリガー
+CREATE OR REPLACE FUNCTION set_thumbnail_templates_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_thumbnail_templates_updated_at ON thumbnail_templates;
+CREATE TRIGGER trg_thumbnail_templates_updated_at
+    BEFORE UPDATE ON thumbnail_templates
+    FOR EACH ROW EXECUTE FUNCTION set_thumbnail_templates_updated_at();

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevKeywordCrudControllerTest.java
@@ -18,7 +18,6 @@ import io.github.tempsotsusei.kotobanotane.domain.story.Story;
 import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
 import java.util.HashMap;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,9 +141,12 @@ class DevKeywordCrudControllerTest {
                             .content(
                                 objectMapper.writeValueAsString(
                                     Map.of(
-                                        "chapterId", baseChapterId,
-                                        "keyword", "initial",
-                                        "keywordPosition", 1))))
+                                        "chapterId",
+                                        baseChapterId,
+                                        "keyword",
+                                        "initial",
+                                        "keywordPosition",
+                                        1))))
                     .andExpect(status().isCreated())
                     .andReturn()
                     .getResponse()

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailTemplateCrudControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/dev/DevThumbnailTemplateCrudControllerTest.java
@@ -1,0 +1,132 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api.dev;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.thumbnail.ThumbnailService;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/** thumbnail template CRUD API の動作を検証する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"test", "dev"})
+class DevThumbnailTemplateCrudControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private ThumbnailService thumbnailService;
+
+  private String baseThumbnailId;
+  private String secondaryThumbnailId;
+
+  @BeforeEach
+  void setUp() {
+    Thumbnail base = thumbnailService.create("/path/to/base.png");
+    Thumbnail secondary = thumbnailService.create("/path/to/secondary.png");
+    baseThumbnailId = base.thumbnailId();
+    secondaryThumbnailId = secondary.thumbnailId();
+  }
+
+  @Test
+  void performsCrudCycle() throws Exception {
+    Map<String, Object> createRequest = new HashMap<>();
+    createRequest.put("thumbnailId", baseThumbnailId);
+
+    // Create
+    MvcResult createResult =
+        mockMvc
+            .perform(
+                post("/api/crud/thumbnail_template")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.thumbnailId").value(baseThumbnailId))
+            .andReturn();
+
+    Map<String, Object> created =
+        objectMapper.readValue(
+            createResult.getResponse().getContentAsString(),
+            new TypeReference<Map<String, Object>>() {});
+    String templateId = created.get("thumbnailTemplateId").toString();
+
+    // List
+    mockMvc.perform(get("/api/crud/thumbnail_templates")).andExpect(status().isOk());
+
+    // Get
+    mockMvc
+        .perform(get("/api/crud/thumbnail_template/" + templateId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.thumbnailTemplateId").value(templateId));
+
+    // Update
+    Map<String, Object> updateRequest = new HashMap<>();
+    updateRequest.put("thumbnailId", secondaryThumbnailId);
+
+    mockMvc
+        .perform(
+            put("/api/crud/thumbnail_template/" + templateId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.thumbnailId").value(secondaryThumbnailId));
+
+    // Delete
+    mockMvc
+        .perform(delete("/api/crud/thumbnail_template/" + templateId))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void returnsBadRequestWhenThumbnailDoesNotExist() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/crud/thumbnail_template")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("thumbnailId", "non-existent"))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsBlankThumbnailIdOnUpdate() throws Exception {
+    String templateId =
+        objectMapper
+            .readTree(
+                mockMvc
+                    .perform(
+                        post("/api/crud/thumbnail_template")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                objectMapper.writeValueAsString(
+                                    Map.of("thumbnailId", baseThumbnailId))))
+                    .andExpect(status().isCreated())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString())
+            .get("thumbnailTemplateId")
+            .asText();
+
+    mockMvc
+        .perform(
+            put("/api/crud/thumbnail_template/" + templateId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("thumbnailId", ""))))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
thumbnail_templatesテーブルを実装する
テスト用のCRUDAPIを実装する

### 動作確認
#### Thumbnail CRUD API テスト
- 開発プロファイル (`SPRING_PROFILES_ACTIVE=dev`) でアプリを起動しておく。
- サムネイル ID はレスポンスの `thumbnailId` を控えておき、後続のリクエストで利用する。
- サムネイル新規作成 (POST /api/crud/thumbnail)
  - curl -X POST -H "Content-Type: application/json" -d ''{"thumbnailPath":"/tmp/thumb.png"}'' http://localhost:${APP_PORT:-8080}/api/crud/thumbnail

- サムネイル一覧取得 (GET /api/crud/thumbnails)
  - curl http://localhost:${APP_PORT:-8080}/api/crud/thumbnails

- サムネイル個別取得 (GET /api/crud/thumbnail/{thumbnailId})
  - curl http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>

- サムネイル情報更新 (PUT /api/crud/thumbnail/{thumbnailId})
  - curl -X PUT -H "Content-Type: application/json" -d ''{"thumbnailPath":"/tmp/thumb-updated.png"}'' http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>

- サムネイル削除 (DELETE /api/crud/thumbnail/{thumbnailId})
  - curl -X DELETE http://localhost:${APP_PORT:-8080}/api/crud/thumbnail/<thumbnailId>
 
### 関連Issue
close #33 