### PR TITLE
feat:api_api/login

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/auth/AuthenticatedTokenService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/auth/AuthenticatedTokenService.java
@@ -1,0 +1,52 @@
+package io.github.tempsotsusei.kotobanotane.application.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * JWT から Auth0 の subject を抽出したり、Bearer トークン文字列を検証して subject を取り出す共通サービス。
+ *
+ * <p>本番 API ではすべての認証済みリクエストでこのサービスを経由し、subject（=auth0Id）が空の場合は 400 (Bad Request)
+ * を返して早期に不正なトークンを検知する。
+ */
+@Service
+public class AuthenticatedTokenService {
+
+  private final JwtDecoder jwtDecoder;
+
+  public AuthenticatedTokenService(JwtDecoder jwtDecoder) {
+    this.jwtDecoder = jwtDecoder;
+  }
+
+  /**
+   * 既に検証済みの {@link Jwt} から subject を取り出して返す。
+   *
+   * @param jwt Spring Security が解決した JWT
+   * @return subject を表す auth0Id
+   */
+  public String extractAuth0Id(Jwt jwt) {
+    String subject = jwt == null ? null : jwt.getSubject();
+    if (!StringUtils.hasText(subject)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "JWT subject is missing.");
+    }
+    return subject;
+  }
+
+  /**
+   * Bearer トークン文字列を検証し、subject を取り出して返す。
+   *
+   * @param bearerToken Authorization ヘッダーで受け取ったトークン
+   * @return subject を表す auth0Id
+   */
+  public String validateAndExtract(String bearerToken) {
+    if (!StringUtils.hasText(bearerToken)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Bearer token is required.");
+    }
+    Jwt jwt = jwtDecoder.decode(bearerToken);
+    return extractAuth0Id(jwt);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/auth/LoginApplicationService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/auth/LoginApplicationService.java
@@ -1,0 +1,29 @@
+package io.github.tempsotsusei.kotobanotane.application.auth;
+
+import io.github.tempsotsusei.kotobanotane.application.user.UserService;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+/** `/api/login` のビジネスロジックを担当するサービス。 */
+@Service
+public class LoginApplicationService {
+
+  private final AuthenticatedTokenService authenticatedTokenService;
+  private final UserService userService;
+
+  public LoginApplicationService(
+      AuthenticatedTokenService authenticatedTokenService, UserService userService) {
+    this.authenticatedTokenService = authenticatedTokenService;
+    this.userService = userService;
+  }
+
+  /**
+   * ログイン API を実行し、ユーザーを特定または作成する。
+   *
+   * @param jwt Spring Security が検証済みの JWT
+   */
+  public void login(Jwt jwt) {
+    String auth0Id = authenticatedTokenService.extractAuth0Id(jwt);
+    userService.findOrCreate(auth0Id);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/LoginController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/LoginController.java
@@ -1,0 +1,34 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import io.github.tempsotsusei.kotobanotane.application.auth.LoginApplicationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** `/api/login` のエンドポイントを提供するコントローラー。 */
+@RestController
+@RequestMapping("/api/login")
+public class LoginController {
+
+  private final LoginApplicationService loginApplicationService;
+
+  public LoginController(LoginApplicationService loginApplicationService) {
+    this.loginApplicationService = loginApplicationService;
+  }
+
+  /**
+   * 認証済みユーザーの存在確認と作成を行う。
+   *
+   * @param authentication Spring Security が解決した JWT 認証情報
+   * @return 200 OK（ボディなし）
+   */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Void> login(JwtAuthenticationToken authentication) {
+    loginApplicationService.login(authentication.getToken());
+    return ResponseEntity.ok().build();
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/auth/AuthenticatedTokenServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/auth/AuthenticatedTokenServiceTest.java
@@ -1,0 +1,78 @@
+package io.github.tempsotsusei.kotobanotane.application.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.web.server.ResponseStatusException;
+
+/** AuthenticatedTokenService の単体テスト。 */
+@ExtendWith(MockitoExtension.class)
+class AuthenticatedTokenServiceTest {
+
+  @Mock private JwtDecoder jwtDecoder;
+
+  @InjectMocks private AuthenticatedTokenService authenticatedTokenService;
+
+  @Test
+  void extractAuth0IdReturnsSubjectWhenPresent() {
+    Jwt jwt = jwtWithSubject("auth0|login");
+
+    String result = authenticatedTokenService.extractAuth0Id(jwt);
+
+    assertThat(result).isEqualTo("auth0|login");
+  }
+
+  @Test
+  void extractAuth0IdThrowsWhenSubjectMissing() {
+    Jwt jwt = jwtWithSubject(null);
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class, () -> authenticatedTokenService.extractAuth0Id(jwt));
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+  }
+
+  @Test
+  void validateAndExtractReturnsSubjectAfterDecoding() {
+    Jwt jwt = jwtWithSubject("auth0|decoded");
+    when(jwtDecoder.decode("token")).thenReturn(jwt);
+
+    String result = authenticatedTokenService.validateAndExtract("token");
+
+    assertThat(result).isEqualTo("auth0|decoded");
+  }
+
+  @Test
+  void validateAndExtractThrowsWhenTokenMissing() {
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> authenticatedTokenService.validateAndExtract("  "));
+
+    assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+  }
+
+  private Jwt jwtWithSubject(String subject) {
+    Instant now = Instant.now();
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("iss", "issuer");
+    if (subject != null) {
+      claims.put("sub", subject);
+    }
+    return new Jwt("token-value", now, now.plusSeconds(60), Map.of("alg", "none"), claims);
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/LoginControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/LoginControllerTest.java
@@ -1,0 +1,40 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/login` エンドポイントの振る舞いを確認する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class LoginControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void returnsOkWhenJwtSubjectPresent() throws Exception {
+    mockMvc
+        .perform(get("/api/login").with(jwt().jwt(jwt -> jwt.subject("auth0|login"))))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void returnsBadRequestWhenSubjectBlank() throws Exception {
+    mockMvc
+        .perform(get("/api/login").with(jwt().jwt(jwt -> jwt.claim("sub", ""))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void returnsUnauthorizedWhenTokenMissing() throws Exception {
+    mockMvc.perform(get("/api/login")).andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
### 概要
api/login APIを実装する

### 動作確認
#### Login API（本番プロファイル）
- プロファイルは `main`（デフォルト）で起動し、Auth0 から取得したアクセストークンを用意する
- `curl -i -H "Authorization: Bearer <アクセストークン>" http://localhost:${APP_PORT:-8080}/api/login`
  - 200 OK が返り、`users` テーブルに存在しない auth0Id の場合は新規作成される
- Authorization ヘッダーを省略すると 401/403 で拒否されること、subject が空の場合は 400 となることを確認
- Base64 でラップされたトークンでも Resolver が自動復号するため、dev 用 JWT テスト API と同じ送信方式で検証可能

### 関連Issue
close #35 