### PR TITLE
feat:api_/api/calendar/stories

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStoriesQueryService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStoriesQueryService.java
@@ -1,0 +1,68 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * カレンダー画面向けに、ユーザー別のストーリー一覧を取得するクエリサービス。
+ *
+ * <p>ストーリー本体とサムネイルパスを突き合わせて、プレゼンテーション層が扱いやすいサマリーへ変換する。
+ */
+@Service
+public class CalendarStoriesQueryService {
+
+  private final StoryRepository storyRepository;
+  private final ThumbnailRepository thumbnailRepository;
+
+  public CalendarStoriesQueryService(
+      StoryRepository storyRepository, ThumbnailRepository thumbnailRepository) {
+    this.storyRepository = storyRepository;
+    this.thumbnailRepository = thumbnailRepository;
+  }
+
+  /**
+   * 指定ユーザーのストーリーを作成日時降順で取得する。
+   *
+   * @param auth0UserId ユーザー ID
+   * @return サムネイルパスを含むサマリー一覧
+   */
+  public List<CalendarStorySummary> fetchByAuth0UserId(String auth0UserId) {
+    List<Story> stories = storyRepository.findAllByAuth0UserIdOrderByCreatedAtDesc(auth0UserId);
+
+    Map<String, String> thumbnailPathMap = loadThumbnailPaths(stories);
+
+    return stories.stream()
+        .map(
+            story ->
+                new CalendarStorySummary(
+                    story.storyId(),
+                    story.storyTitle(),
+                    story.thumbnailId() == null ? null : thumbnailPathMap.get(story.thumbnailId()),
+                    story.createdAt()))
+        .toList();
+  }
+
+  /** ストーリー一覧から必要なサムネイルを抽出し、ID→パスのマップを生成する。 */
+  private Map<String, String> loadThumbnailPaths(List<Story> stories) {
+    Set<String> thumbnailIds =
+        stories.stream()
+            .map(Story::thumbnailId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    if (thumbnailIds.isEmpty()) {
+      return Map.of();
+    }
+
+    return thumbnailRepository.findAllByIds(thumbnailIds).stream()
+        .collect(Collectors.toMap(Thumbnail::thumbnailId, Thumbnail::thumbnailPath));
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStorySummary.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStorySummary.java
@@ -1,0 +1,7 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import java.time.Instant;
+
+/** カレンダービュー向けのストーリーサマリーを表すレコード。 */
+public record CalendarStorySummary(
+    String storyId, String storyTitle, String thumbnailPath, Instant createdAt) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/StoryRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/story/StoryRepository.java
@@ -10,6 +10,14 @@ public interface StoryRepository {
 
   List<Story> findAll();
 
+  /**
+   * 指定ユーザーが作成したストーリーを作成日時の降順で取得する。
+   *
+   * @param auth0UserId ユーザー ID
+   * @return 作成日時が新しい順に並んだストーリー一覧
+   */
+  List<Story> findAllByAuth0UserIdOrderByCreatedAtDesc(String auth0UserId);
+
   Story save(Story story);
 
   void deleteById(String storyId);

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/ThumbnailRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/thumbnail/ThumbnailRepository.java
@@ -1,5 +1,6 @@
 package io.github.tempsotsusei.kotobanotane.domain.thumbnail;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +25,14 @@ public interface ThumbnailRepository {
    * @return サムネイルの一覧
    */
   List<Thumbnail> findAll();
+
+  /**
+   * 複数 ID のサムネイルをまとめて取得する。
+   *
+   * @param thumbnailIds 取得対象の ID 群
+   * @return 見つかったサムネイル一覧
+   */
+  List<Thumbnail> findAllByIds(Collection<String> thumbnailIds);
 
   /**
    * サムネイルを新規作成または更新する。

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryJpaRepository.java
@@ -1,6 +1,10 @@
 package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** stories テーブルにアクセスする Spring Data JPA リポジトリ。 */
-public interface StoryJpaRepository extends JpaRepository<StoryEntity, String> {}
+public interface StoryJpaRepository extends JpaRepository<StoryEntity, String> {
+
+  List<StoryEntity> findByAuth0UserIdOrderByCreatedAtDesc(String auth0UserId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/story/StoryRepositoryImpl.java
@@ -29,6 +29,13 @@ public class StoryRepositoryImpl implements StoryRepository {
   }
 
   @Override
+  public List<Story> findAllByAuth0UserIdOrderByCreatedAtDesc(String auth0UserId) {
+    return storyJpaRepository.findByAuth0UserIdOrderByCreatedAtDesc(auth0UserId).stream()
+        .map(StoryMapper::toDomain)
+        .toList();
+  }
+
+  @Override
   @Transactional
   public Story save(Story story) {
     StoryEntity entity =

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/thumbnail/ThumbnailRepositoryImpl.java
@@ -2,6 +2,7 @@ package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail
 
 import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
 import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
@@ -28,6 +29,17 @@ public class ThumbnailRepositoryImpl implements ThumbnailRepository {
   @Override
   public List<Thumbnail> findAll() {
     return thumbnailJpaRepository.findAll().stream().map(ThumbnailMapper::toDomain).toList();
+  }
+
+  /** 指定 ID 群のサムネイルをまとめて取得する。 */
+  @Override
+  public List<Thumbnail> findAllByIds(Collection<String> thumbnailIds) {
+    if (thumbnailIds == null || thumbnailIds.isEmpty()) {
+      return List.of();
+    }
+    return thumbnailJpaRepository.findAllById(thumbnailIds).stream()
+        .map(ThumbnailMapper::toDomain)
+        .toList();
   }
 
   /**

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/CalendarStoryController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/CalendarStoryController.java
@@ -1,0 +1,62 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import io.github.tempsotsusei.kotobanotane.application.auth.AuthenticatedTokenService;
+import io.github.tempsotsusei.kotobanotane.application.story.CalendarStoriesQueryService;
+import io.github.tempsotsusei.kotobanotane.application.story.CalendarStorySummary;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * カレンダー画面のストーリー一覧を提供する本番 API。
+ *
+ * <p>認証済みユーザーが作成したストーリーを作成日時降順で返却する。
+ */
+@RestController
+@RequestMapping("/api/calendar/stories")
+public class CalendarStoryController {
+
+  private final AuthenticatedTokenService authenticatedTokenService;
+  private final CalendarStoriesQueryService calendarStoriesQueryService;
+  private final TimeProvider timeProvider;
+
+  public CalendarStoryController(
+      AuthenticatedTokenService authenticatedTokenService,
+      CalendarStoriesQueryService calendarStoriesQueryService,
+      TimeProvider timeProvider) {
+    this.authenticatedTokenService = authenticatedTokenService;
+    this.calendarStoriesQueryService = calendarStoriesQueryService;
+    this.timeProvider = timeProvider;
+  }
+
+  /**
+   * 認証済みユーザーのストーリー一覧を取得する。
+   *
+   * @param authentication Spring Security が検証した JWT 認証情報
+   * @return 作成日時降順で並んだレスポンス
+   */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public List<CalendarStoryResponse> list(JwtAuthenticationToken authentication) {
+    String auth0Id = authenticatedTokenService.extractAuth0Id(authentication.getToken());
+    return calendarStoriesQueryService.fetchByAuth0UserId(auth0Id).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  private CalendarStoryResponse toResponse(CalendarStorySummary summary) {
+    return new CalendarStoryResponse(
+        summary.storyId(),
+        summary.storyTitle(),
+        summary.thumbnailPath(),
+        timeProvider.formatIso(summary.createdAt()));
+  }
+
+  /** `/api/calendar/stories` のレスポンス DTO。 */
+  public record CalendarStoryResponse(
+      String storyId, String storyTitle, String thumbnailPath, String createdAt) {}
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStoriesQueryServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/CalendarStoriesQueryServiceTest.java
@@ -1,0 +1,92 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** CalendarStoriesQueryService のユニットテスト。 */
+@ExtendWith(MockitoExtension.class)
+class CalendarStoriesQueryServiceTest {
+
+  @Mock private StoryRepository storyRepository;
+  @Mock private ThumbnailRepository thumbnailRepository;
+
+  @InjectMocks private CalendarStoriesQueryService calendarStoriesQueryService;
+
+  @Test
+  void fetchByAuth0UserIdEnrichesThumbnailPaths() {
+    Story storyWithThumbnail =
+        new Story(
+            "story-1",
+            "auth0|user",
+            "First Story",
+            "thumb-1",
+            Instant.parse("2025-01-01T00:00:00Z"),
+            Instant.parse("2025-01-01T00:00:00Z"));
+    Story storyWithoutThumbnail =
+        new Story(
+            "story-2",
+            "auth0|user",
+            "Second Story",
+            null,
+            Instant.parse("2025-01-02T00:00:00Z"),
+            Instant.parse("2025-01-02T00:00:00Z"));
+
+    when(storyRepository.findAllByAuth0UserIdOrderByCreatedAtDesc("auth0|user"))
+        .thenReturn(List.of(storyWithThumbnail, storyWithoutThumbnail));
+    when(thumbnailRepository.findAllByIds(Set.of("thumb-1")))
+        .thenReturn(
+            List.of(
+                new Thumbnail(
+                    "thumb-1",
+                    "/thumb/path.png",
+                    Instant.parse("2025-01-01T00:00:00Z"),
+                    Instant.parse("2025-01-01T00:00:00Z"))));
+
+    List<CalendarStorySummary> summaries =
+        calendarStoriesQueryService.fetchByAuth0UserId("auth0|user");
+
+    assertThat(summaries).hasSize(2);
+    Map<String, CalendarStorySummary> byId =
+        summaries.stream()
+            .collect(java.util.stream.Collectors.toMap(CalendarStorySummary::storyId, s -> s));
+    assertThat(byId.get("story-1").thumbnailPath()).isEqualTo("/thumb/path.png");
+    assertThat(byId.get("story-2").thumbnailPath()).isNull();
+  }
+
+  @Test
+  void fetchByAuth0UserIdSkipsThumbnailLookupWhenNotNeeded() {
+    Story story =
+        new Story(
+            "story-3",
+            "auth0|user",
+            "Story",
+            null,
+            Instant.parse("2025-01-03T00:00:00Z"),
+            Instant.parse("2025-01-03T00:00:00Z"));
+
+    when(storyRepository.findAllByAuth0UserIdOrderByCreatedAtDesc("auth0|user"))
+        .thenReturn(List.of(story));
+
+    List<CalendarStorySummary> summaries =
+        calendarStoriesQueryService.fetchByAuth0UserId("auth0|user");
+
+    assertThat(summaries).hasSize(1);
+    assertThat(summaries.getFirst().thumbnailPath()).isNull();
+    verifyNoInteractions(thumbnailRepository);
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/CalendarStoryControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/CalendarStoryControllerTest.java
@@ -1,0 +1,69 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story.StoryJpaRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail.ThumbnailJpaRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/calendar/stories` の統合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CalendarStoryControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private StoryRepository storyRepository;
+  @Autowired private ThumbnailRepository thumbnailRepository;
+  @Autowired private StoryJpaRepository storyJpaRepository;
+  @Autowired private ThumbnailJpaRepository thumbnailJpaRepository;
+
+  @BeforeEach
+  void setUp() {
+    storyJpaRepository.deleteAll();
+    thumbnailJpaRepository.deleteAll();
+  }
+
+  @Test
+  void returnsCalendarStoriesForAuthenticatedUser() throws Exception {
+    String auth0Id = "auth0|calendar";
+    Instant createdLatest = Instant.parse("2025-03-02T10:15:30Z");
+    Instant createdOld = Instant.parse("2025-02-28T08:00:00Z");
+
+    thumbnailRepository.save(new Thumbnail("thumb-1", "/images/thumb.png", createdOld, createdOld));
+
+    storyRepository.save(
+        new Story("story-new", auth0Id, "Latest Story", "thumb-1", createdLatest, createdLatest));
+    storyRepository.save(
+        new Story("story-old", auth0Id, "Old Story", null, createdOld, createdOld));
+
+    mockMvc
+        .perform(get("/api/calendar/stories").with(jwt().jwt(jwt -> jwt.subject(auth0Id))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].storyId").value("story-new"))
+        .andExpect(jsonPath("$[0].thumbnailPath").value("/images/thumb.png"))
+        .andExpect(jsonPath("$[0].createdAt").isNotEmpty())
+        .andExpect(jsonPath("$[1].storyId").value("story-old"))
+        .andExpect(jsonPath("$[1].thumbnailPath").value(nullValue()));
+  }
+
+  @Test
+  void returnsUnauthorizedWithoutJwt() throws Exception {
+    mockMvc.perform(get("/api/calendar/stories")).andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
### 概要
/api/calendar/stories APIを実装する

### 動作確認
#### Calendar Stories API（本番プロファイル）
- Auth0 トークンでログインした状態で `GET /api/calendar/stories` を実行する
- `curl -H "Authorization: Bearer <アクセストークン>" http://localhost:${APP_PORT:-8080}/api/calendar/stories`
  - レスポンスは作成日時降順の配列で、`storyId`, `storyTitle`, `thumbnailPath`, `createdAt` を返す
  - サムネイル未設定のストーリーは `thumbnailPath: null` になる
- JWT を省略すると 401 になることを確認
- ストーリーが存在しない場合は `[]` が返る。件数や並び順に違和感があれば DB 状態と `CalendarStoriesQueryService` のログを確認

### 関連Issue
close #27 