### PR TITLE
feat:api_/api/story/chapter/keywords

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterKeywordsController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterKeywordsController.java
@@ -1,0 +1,32 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import io.github.tempsotsusei.kotobanotane.application.llm.KeywordListsGenerationService;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 章本文が存在しない初回フェーズ向けにキーワード候補を返すコントローラー。
+ *
+ * <p>LLM から取得した 4 語×3 セットの配列をそのままクライアントへ返却する。
+ */
+@RestController
+@RequestMapping("/api/story/chapter/keywords")
+public class StoryChapterKeywordsController {
+
+  private final KeywordListsGenerationService keywordListsGenerationService;
+
+  public StoryChapterKeywordsController(
+      KeywordListsGenerationService keywordListsGenerationService) {
+    this.keywordListsGenerationService = keywordListsGenerationService;
+  }
+
+  /** 初回サジェスト用のキーワードを取得する。 */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public List<List<String>> getInitialKeywords() {
+    return keywordListsGenerationService.generateInitialKeywords();
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/llm/KeywordListsGenerationServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/llm/KeywordListsGenerationServiceTest.java
@@ -3,6 +3,7 @@ package io.github.tempsotsusei.kotobanotane.application.llm;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -13,6 +14,7 @@ import io.github.tempsotsusei.kotobanotane.infrastructure.external.openai.OpenAi
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class KeywordListsGenerationServiceTest {
@@ -49,6 +51,27 @@ class KeywordListsGenerationServiceTest {
   void generateThrowsForBlankInput() {
     // 入力が空文字の場合に例外が送出されることを確認する。
     assertThatThrownBy(() -> service.generate(" ")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void generateInitialKeywordsUsesRandomizedPrompt() {
+    ObjectNode response = objectMapper.createObjectNode();
+    ArrayNode keywords = objectMapper.createArrayNode();
+    keywords.add(arrayOf("あお", "あか", "きいろ", "みどり"));
+    keywords.add(arrayOf("そら", "うみ", "ほし", "つき"));
+    keywords.add(arrayOf("はる", "なつ", "あき", "ふゆ"));
+    response.set("keywords", keywords);
+
+    when(openAiClient.requestStructuredJson(any(OpenAiStructuredRequest.class)))
+        .thenReturn(response);
+
+    List<List<String>> lists = service.generateInitialKeywords();
+
+    assertThat(lists).hasSize(3);
+    ArgumentCaptor<OpenAiStructuredRequest> captor =
+        ArgumentCaptor.forClass(OpenAiStructuredRequest.class);
+    verify(openAiClient).requestStructuredJson(captor.capture());
+    assertThat(captor.getValue().userInput()).contains("seed=");
   }
 
   private JsonNode arrayOf(String... values) {

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterKeywordsControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterKeywordsControllerTest.java
@@ -1,0 +1,45 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.tempsotsusei.kotobanotane.application.llm.KeywordListsGenerationService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/story/chapter/keywords` の挙動を確認する統合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StoryChapterKeywordsControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private KeywordListsGenerationService keywordListsGenerationService;
+
+  @Test
+  void returnsKeywordsForAuthenticatedUser() throws Exception {
+    when(keywordListsGenerationService.generateInitialKeywords())
+        .thenReturn(List.of(List.of("あお", "あか", "きいろ", "みどり")));
+
+    mockMvc
+        .perform(get("/api/story/chapter/keywords").with(jwt()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0][0]").value("あお"))
+        .andExpect(jsonPath("$[0][3]").value("みどり"));
+  }
+
+  @Test
+  void rejectsWhenUnauthenticated() throws Exception {
+    mockMvc.perform(get("/api/story/chapter/keywords")).andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
### 概要
/api/story/chapter/keywords APIを実装する

### 動作確認
#### Story Chapter Keywords API（初回サジェスト）
- `curl -H "Authorization: Bearer <アクセストークン>" http://localhost:${APP_PORT:-8080}/api/story/chapter/keywords`
  - 4語×3セットの JSON 配列が返る（内容は呼び出しごとにランダム）
  - 期待例: `[["ひかり","あめ","まくら","おにぎり"], ...]`
- JWT を省略すると 401 になることを確認
- LLM 側のレスポンスが遅い/失敗した場合は 502/503 が返るため、ログで `KeywordListsGenerationService` の WARN を確認してリトライ

### 関連Issue
close #28 