### PR TITLE
feat:api_/api/story/chapter/next

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterJsonTextService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterJsonTextService.java
@@ -1,0 +1,143 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * TipTap 形式の章 JSON を解析し、LLM へ渡すプレーンテキストやカスタム単語の位置を抽出するサービス。
+ *
+ * <p>章 JSON の構造が不正な場合は 400(BAD_REQUEST) を通知する。`customWord` ノードの attrs.text
+ * を本文へそのまま挿入し、`collectWordsWithOffset` 用のリストにも格納する。
+ */
+@Service
+public class ChapterJsonTextService {
+
+  private static final String TYPE_DOC = "doc";
+  private static final String TYPE_PARAGRAPH = "paragraph";
+  private static final String TYPE_TEXT = "text";
+  private static final String TYPE_CUSTOM_WORD = "customWord";
+  private static final String TYPE_HARD_BREAK = "hardBreak";
+
+  /**
+   * TipTap JSON を走査し、本文のプレーンテキストと `customWord` の出現位置をまとめて返す。
+   *
+   * @param chapterJson 章 JSON
+   * @return 文字列化結果と単語位置の解析情報
+   */
+  public ChapterTextAnalysis analyze(JsonNode chapterJson) {
+    JsonNode root = Objects.requireNonNull(chapterJson, "chapterJson must not be null");
+    ensureDocType(root);
+
+    StringBuilder builder = new StringBuilder();
+    List<KeywordPosition> keywords = new ArrayList<>();
+    JsonNode blocks = root.path("content");
+    if (blocks.isMissingNode()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson must contain content array");
+    }
+    if (!blocks.isArray()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson content must be an array");
+    }
+
+    boolean firstBlock = true;
+    for (JsonNode block : blocks) {
+      if (!firstBlock) {
+        builder.append('\n');
+      }
+      appendBlock(block, builder, keywords);
+      firstBlock = false;
+    }
+
+    return new ChapterTextAnalysis(builder.toString(), List.copyOf(keywords));
+  }
+
+  /**
+   * ルートノードが TipTap の doc であることを検証する。
+   *
+   * @param root ルート JSON
+   */
+  private void ensureDocType(JsonNode root) {
+    if (!root.isObject()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson must be a JSON object of TipTap doc");
+    }
+    String type = root.path("type").asText();
+    if (!TYPE_DOC.equals(type)) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson root type must be 'doc'");
+    }
+  }
+
+  /**
+   * paragraph などのブロックノードを文字列に変換する。
+   *
+   * @param block 現在のブロック
+   * @param builder 出力先文字列
+   * @param keywords 単語位置リスト
+   */
+  private void appendBlock(JsonNode block, StringBuilder builder, List<KeywordPosition> keywords) {
+    if (block == null || block.isNull() || block.isMissingNode()) {
+      return;
+    }
+    if (!TYPE_PARAGRAPH.equals(block.path("type").asText())) {
+      appendInlineNodes(block, builder, keywords);
+      return;
+    }
+    appendInlineNodes(block.path("content"), builder, keywords);
+  }
+
+  /**
+   * インラインノードを再帰的に連結する。
+   *
+   * @param node 処理対象ノード
+   * @param builder 出力先文字列
+   * @param keywords 単語位置リスト
+   */
+  private void appendInlineNodes(
+      JsonNode node, StringBuilder builder, List<KeywordPosition> keywords) {
+    if (node == null || node.isMissingNode() || node.isNull()) {
+      return;
+    }
+    if (node.isArray()) {
+      for (JsonNode child : node) {
+        appendInlineNodes(child, builder, keywords);
+      }
+      return;
+    }
+
+    String type = node.path("type").asText();
+    switch (type) {
+      case TYPE_TEXT -> builder.append(node.path("text").asText(""));
+      case TYPE_CUSTOM_WORD -> appendCustomWord(node, builder, keywords);
+      case TYPE_HARD_BREAK -> builder.append('\n');
+      default -> appendInlineNodes(node.path("content"), builder, keywords);
+    }
+  }
+
+  /**
+   * `customWord` ノードを文字列に追加し、位置情報を記録する。
+   *
+   * @param node `customWord` ノード
+   * @param builder 出力先文字列
+   * @param keywords 単語位置リスト
+   */
+  private void appendCustomWord(
+      JsonNode node, StringBuilder builder, List<KeywordPosition> keywords) {
+    JsonNode attrs = node.path("attrs");
+    if (!attrs.isObject()) {
+      return;
+    }
+    String keyword = attrs.path("text").asText("");
+    if (keyword.isEmpty()) {
+      return;
+    }
+    keywords.add(new KeywordPosition(keyword, builder.length()));
+    builder.append(keyword);
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterTextAnalysis.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterTextAnalysis.java
@@ -1,0 +1,11 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+import java.util.List;
+
+/**
+ * 章 JSON を文字列表現へ変換した結果と、任意の単語出現位置をまとめた解析結果 DTO。
+ *
+ * @param plainText TipTap JSON を復元した文字列（改行を含む）
+ * @param keywordsWithOffset `collectWordsWithOffset` 用の単語と文字位置リスト
+ */
+public record ChapterTextAnalysis(String plainText, List<KeywordPosition> keywordsWithOffset) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/KeywordPosition.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/chapter/KeywordPosition.java
@@ -1,0 +1,9 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+/**
+ * テキスト内の単語と、その単語が何文字目に登場するかの情報を表す DTO。
+ *
+ * @param keyword 章 JSON から抽出した単語
+ * @param position 文字列先頭からのオフセット（0 origin）
+ */
+public record KeywordPosition(String keyword, int position) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryChapterNextService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryChapterNextService.java
@@ -1,0 +1,62 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterJsonTextService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterTextAnalysis;
+import io.github.tempsotsusei.kotobanotane.application.llm.KeywordListsGenerationService;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * `/api/story/chapter/next` から呼び出され、章 JSON を整形して LLM に渡すアプリケーションサービス。
+ *
+ * <p>JSON をプレーンテキストに変換し、文字数（0 &lt;= length &lt;= 200）を検証した上で `KeywordListsGenerationService` を呼び出す。
+ */
+@Service
+public class StoryChapterNextService {
+
+  private static final int MAX_TEXT_LENGTH = 200;
+
+  private final ChapterJsonTextService chapterJsonTextService;
+  private final KeywordListsGenerationService keywordListsGenerationService;
+
+  /** 章 JSON の解析サービスと LLM 呼び出しサービスを受け取る。 */
+  public StoryChapterNextService(
+      ChapterJsonTextService chapterJsonTextService,
+      KeywordListsGenerationService keywordListsGenerationService) {
+    this.chapterJsonTextService = chapterJsonTextService;
+    this.keywordListsGenerationService = keywordListsGenerationService;
+  }
+
+  /**
+   * TipTap JSON を受け取り、文字列化→バリデーション→LLM 呼び出しまでを実行する。
+   *
+   * @param chapterJson フロントエンドから渡される章 JSON
+   * @return LLM が生成した 4 語 × 3 セットのリスト
+   */
+  public List<List<String>> generateNextChapterKeywords(JsonNode chapterJson) {
+    ChapterTextAnalysis analysis = chapterJsonTextService.analyze(chapterJson);
+    String plainText = analysis.plainText();
+    validateTextLength(plainText);
+    return keywordListsGenerationService.generate(plainText);
+  }
+
+  /**
+   * 文字列化した本文が 1〜200 文字の範囲に収まっているか検証する。
+   *
+   * @param text 章本文
+   */
+  private void validateTextLength(String text) {
+    if (!StringUtils.hasText(text)) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson text length must be between 1 and 200");
+    }
+    if (text.length() > MAX_TEXT_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson text length must be between 1 and 200");
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterNextController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterNextController.java
@@ -1,0 +1,46 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryChapterNextService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 直前章の JSON を受け取り、次章生成用キーワードを返却する本番向け API。
+ *
+ * <p>LLM へは文字列化した本文のみを渡し、レスポンスは 4 語 × 3 セットの配列となる。
+ */
+@RestController
+@RequestMapping("/api/story/chapter/next")
+public class StoryChapterNextController {
+
+  private final StoryChapterNextService storyChapterNextService;
+
+  public StoryChapterNextController(StoryChapterNextService storyChapterNextService) {
+    this.storyChapterNextService = storyChapterNextService;
+  }
+
+  /**
+   * TipTap JSON からキーワードを生成する。
+   *
+   * @param request 章 JSON を含むリクエスト DTO
+   * @return LLM が生成したキーワード集合
+   */
+  @PostMapping
+  @PreAuthorize("isAuthenticated()")
+  public List<List<String>> generateNextKeywords(
+      @Valid @RequestBody StoryChapterNextRequest request) {
+    return storyChapterNextService.generateNextChapterKeywords(request.chapterJson());
+  }
+
+  /** `/api/story/chapter/next` のリクエスト DTO。 */
+  public record StoryChapterNextRequest(
+      @JsonProperty("chapterJson") @NotNull JsonNode chapterJson) {}
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterJsonTextServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/chapter/ChapterJsonTextServiceTest.java
@@ -1,0 +1,131 @@
+package io.github.tempsotsusei.kotobanotane.application.chapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+class ChapterJsonTextServiceTest {
+
+  private static final String SAMPLE_JSON =
+      """
+			{
+				"type": "doc",
+				"content": [
+					{
+						"type": "paragraph",
+						"content": [
+							{
+								"type": "text",
+								"text": "これはテストです"
+							}
+						]
+					},
+					{
+						"type": "paragraph"
+					},
+					{
+						"type": "paragraph",
+						"content": [
+							{
+								"type": "text",
+								"text": "あ"
+							}
+						]
+					},
+					{
+						"type": "paragraph",
+						"content": [
+							{
+								"type": "text",
+								"text": "い"
+							},
+							{
+								"type": "customWord",
+								"attrs": {
+									"text": "ふね",
+									"droppedId": 1
+								}
+							},
+							{
+								"type": "text",
+								"text": "う"
+							}
+						]
+					},
+					{
+						"type": "paragraph",
+						"content": [
+							{
+								"type": "customWord",
+								"attrs": {
+									"text": "そら",
+									"droppedId": 1
+								}
+							}
+						]
+					},
+					{
+						"type": "paragraph"
+					},
+					{
+						"type": "paragraph",
+						"content": [
+							{
+								"type": "customWord",
+								"attrs": {
+									"text": "ともだち",
+									"droppedId": 1
+								}
+							},
+							{
+								"type": "customWord",
+								"attrs": {
+									"text": "ぼうけん",
+									"droppedId": 1
+								}
+							},
+							{
+								"type": "text",
+								"text": " "
+							}
+						]
+					}
+				]
+			}
+			""";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ChapterJsonTextService service = new ChapterJsonTextService();
+
+  /** TipTap JSON 全体を渡したとき、文字列化と customWord 抽出が正しく行われることを検証する。 */
+  @Test
+  void analyzeConvertsJsonToPlainTextAndCollectsKeywords() throws Exception {
+    JsonNode chapterJson = objectMapper.readTree(SAMPLE_JSON);
+
+    ChapterTextAnalysis analysis = service.analyze(chapterJson);
+
+    assertThat(analysis.plainText()).isEqualTo("これはテストです\n\nあ\nいふねう\nそら\n\nともだちぼうけん ");
+    assertThat(analysis.keywordsWithOffset())
+        .containsExactly(
+            new KeywordPosition("ふね", analysis.plainText().indexOf("ふね")),
+            new KeywordPosition("そら", analysis.plainText().indexOf("そら")),
+            new KeywordPosition("ともだち", analysis.plainText().indexOf("ともだち")),
+            new KeywordPosition("ぼうけん", analysis.plainText().indexOf("ぼうけん")));
+  }
+
+  /** ルート type が doc 以外の場合に 400 エラーへ変換されることを確認する。 */
+  @Test
+  void analyzeRejectsJsonWithoutDocType() {
+    ObjectNode invalid = objectMapper.createObjectNode();
+    invalid.put("type", "paragraph");
+
+    assertThatThrownBy(() -> service.analyze(invalid))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("doc");
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/StoryChapterNextServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/StoryChapterNextServiceTest.java
@@ -1,0 +1,72 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterJsonTextService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterTextAnalysis;
+import io.github.tempsotsusei.kotobanotane.application.llm.KeywordListsGenerationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.server.ResponseStatusException;
+
+class StoryChapterNextServiceTest {
+
+  private final ChapterJsonTextService chapterJsonTextService =
+      Mockito.mock(ChapterJsonTextService.class);
+  private final KeywordListsGenerationService keywordListsGenerationService =
+      Mockito.mock(KeywordListsGenerationService.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private StoryChapterNextService service;
+  private JsonNode chapterJson;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    service = new StoryChapterNextService(chapterJsonTextService, keywordListsGenerationService);
+    chapterJson = objectMapper.readTree("{\"type\":\"doc\",\"content\":[]}");
+  }
+
+  /** 正常な JSON を受け取った際に LLM 呼び出しが行われることを確認する。 */
+  @Test
+  void generateNextChapterKeywordsCallsLlmWhenValid() {
+    when(chapterJsonTextService.analyze(chapterJson))
+        .thenReturn(new ChapterTextAnalysis("ひかりの道", List.of()));
+    when(keywordListsGenerationService.generate("ひかりの道"))
+        .thenReturn(List.of(List.of("ひかり", "みち", "そら", "ゆめ")));
+
+    List<List<String>> response = service.generateNextChapterKeywords(chapterJson);
+
+    assertThat(response).hasSize(1);
+    verify(keywordListsGenerationService).generate("ひかりの道");
+  }
+
+  /** 文字列化した本文が空の場合に 400 エラーとなることを検証する。 */
+  @Test
+  void generateNextChapterKeywordsRejectsEmptyText() {
+    when(chapterJsonTextService.analyze(chapterJson))
+        .thenReturn(new ChapterTextAnalysis(" \n", List.of()));
+
+    assertThatThrownBy(() -> service.generateNextChapterKeywords(chapterJson))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("between 1 and 200");
+  }
+
+  /** 200 文字を超える本文が送られた場合に 400 エラーで拒否されることを検証する。 */
+  @Test
+  void generateNextChapterKeywordsRejectsOverLimitText() {
+    String longText = "あ".repeat(201);
+    when(chapterJsonTextService.analyze(chapterJson))
+        .thenReturn(new ChapterTextAnalysis(longText, List.of()));
+
+    assertThatThrownBy(() -> service.generateNextChapterKeywords(chapterJson))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("between 1 and 200");
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterNextControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryChapterNextControllerTest.java
@@ -1,0 +1,88 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.tempsotsusei.kotobanotane.application.story.StoryChapterNextService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+/** `/api/story/chapter/next` の振る舞いを確認する結合テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StoryChapterNextControllerTest {
+
+  private static final String REQUEST_BODY =
+      """
+			{
+				"chapterJson": {
+					"type": "doc",
+					"content": [
+						{ "type": "paragraph" }
+					]
+				}
+			}
+			""";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private StoryChapterNextService storyChapterNextService;
+
+  /** JWT 付きリクエストでキーワード配列が返る正常系を検証する。 */
+  @Test
+  void returnsKeywordsWhenAuthenticated() throws Exception {
+    when(storyChapterNextService.generateNextChapterKeywords(any()))
+        .thenReturn(List.of(List.of("ひかり", "そら", "みち", "ゆめ")));
+
+    mockMvc
+        .perform(
+            post("/api/story/chapter/next")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0][1]").value("そら"));
+  }
+
+  /** 未認証リクエストが 401 で拒否されることを確認する。 */
+  @Test
+  void rejectsWhenUnauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/story/chapter/next")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isUnauthorized());
+  }
+
+  /** Service 層からの 400 エラーが Controller でも 400 として伝播することを検証する。 */
+  @Test
+  void returnsBadRequestWhenServiceThrows() throws Exception {
+    when(storyChapterNextService.generateNextChapterKeywords(any()))
+        .thenThrow(
+            new ResponseStatusException(
+                HttpStatus.BAD_REQUEST, "chapterJson text length must be between 1 and 200"));
+
+    mockMvc
+        .perform(
+            post("/api/story/chapter/next")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
/api/story/chapter/next APIを実装する

### 動作確認
#### Story Chapter Next API（本番プロファイル）

- `curl -X POST -H "Authorization: Bearer <アクセストークン>" -H "Content-Type: application/json" -d @chapter.json http://localhost:${APP_PORT:-8080}/api/story/chapter/next`
  - `chapter.json` には TipTap 形式の `{"chapterJson": { ... }}` を含める。`docs/internal/test_chapter_json.md` を流用可能。
- レスポンスは 4語×3セットの JSON 配列。例: `[["はな","かぜ","くも","ほし"], ...]`
- 章 JSON をプレーンテキスト化した際に 1〜200 文字を超える場合（改行込み）は 400 が返ることを確認
- JWT を省略すると 401、JSON 構造が不正の場合は 400 となる

### 関連Issue
close #29 