### PR TITLE
feat:api_/api/thumbnail-templates

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateQueryService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateQueryService.java
@@ -1,0 +1,83 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplateRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * テンプレート用のサムネイルだけを取得する読み取り専用サービス。
+ *
+ * <p>thumbnail_templates に存在する thumbnail_id を起点に、thumbnails の id/path を返却する。 並び順はテンプレートの createdAt
+ * 降順で固定。
+ */
+@Service
+@Transactional(readOnly = true)
+public class ThumbnailTemplateQueryService {
+
+  private final ThumbnailTemplateRepository thumbnailTemplateRepository;
+  private final ThumbnailRepository thumbnailRepository;
+
+  public ThumbnailTemplateQueryService(
+      ThumbnailTemplateRepository thumbnailTemplateRepository,
+      ThumbnailRepository thumbnailRepository) {
+    this.thumbnailTemplateRepository = thumbnailTemplateRepository;
+    this.thumbnailRepository = thumbnailRepository;
+  }
+
+  /**
+   * テンプレートに紐づくサムネイルを取得する。
+   *
+   * <p>テンプレートに存在しないサムネイル ID は無視し、取得できたものだけを返す。
+   *
+   * @return thumbnailId と thumbnailPath の一覧（createdAt 降順）
+   */
+  public List<ThumbnailTemplateSummary> listTemplates() {
+    List<ThumbnailTemplate> templates = thumbnailTemplateRepository.findAll();
+    Map<String, Thumbnail> thumbnailMap = toThumbnailMap(templates);
+
+    return templates.stream()
+        .sorted(Comparator.comparing(ThumbnailTemplate::createdAt).reversed())
+        .map(template -> toSummary(template, thumbnailMap.get(template.thumbnailId())))
+        .filter(TemplateConversionResult::isPresent)
+        .map(TemplateConversionResult::summary)
+        .toList();
+  }
+
+  private Map<String, Thumbnail> toThumbnailMap(List<ThumbnailTemplate> templates) {
+    List<String> thumbnailIds =
+        templates.stream().map(ThumbnailTemplate::thumbnailId).distinct().toList();
+    return thumbnailRepository.findAllByIds(thumbnailIds).stream()
+        .collect(Collectors.toMap(Thumbnail::thumbnailId, Function.identity()));
+  }
+
+  private TemplateConversionResult toSummary(
+      ThumbnailTemplate template, Thumbnail thumbnailOrNull) {
+    if (thumbnailOrNull == null) {
+      // テンプレートに紐づくサムネイルが存在しない場合はスキップ
+      return TemplateConversionResult.empty();
+    }
+    ThumbnailTemplateSummary summary =
+        new ThumbnailTemplateSummary(
+            thumbnailOrNull.thumbnailId(), thumbnailOrNull.thumbnailPath());
+    return TemplateConversionResult.of(summary);
+  }
+
+  /** Optional の代わりに small DTO で存在判定を行う。 */
+  private record TemplateConversionResult(ThumbnailTemplateSummary summary, boolean isPresent) {
+    static TemplateConversionResult of(ThumbnailTemplateSummary summary) {
+      return new TemplateConversionResult(summary, true);
+    }
+
+    static TemplateConversionResult empty() {
+      return new TemplateConversionResult(null, false);
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateSummary.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateSummary.java
@@ -1,0 +1,9 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate;
+
+/**
+ * テンプレートとして公開するサムネイルの簡易情報。
+ *
+ * @param thumbnailId テンプレートに紐づくサムネイル ID
+ * @param thumbnailPath テンプレート画像のパス
+ */
+public record ThumbnailTemplateSummary(String thumbnailId, String thumbnailPath) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/ThumbnailTemplateController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/ThumbnailTemplateController.java
@@ -1,0 +1,44 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateQueryService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateSummary;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * サムネイルテンプレート一覧を返す本番向け API。
+ *
+ * <p>thumbnail_templates に登録されているものだけを返却し、テンプレート以外のサムネイルは含めない。
+ */
+@RestController
+@RequestMapping("/api/thumbnail-templates")
+public class ThumbnailTemplateController {
+
+  private final ThumbnailTemplateQueryService thumbnailTemplateQueryService;
+
+  public ThumbnailTemplateController(ThumbnailTemplateQueryService thumbnailTemplateQueryService) {
+    this.thumbnailTemplateQueryService = thumbnailTemplateQueryService;
+  }
+
+  /**
+   * テンプレートとして登録されているサムネイル一覧を返す。
+   *
+   * @return thumbnailId / thumbnailPath の配列（createdAt 降順）
+   */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public List<ThumbnailTemplateResponse> list() {
+    return thumbnailTemplateQueryService.listTemplates().stream().map(this::toResponse).toList();
+  }
+
+  /** `ThumbnailTemplateSummary` を API レスポンスに変換する。 */
+  private ThumbnailTemplateResponse toResponse(ThumbnailTemplateSummary summary) {
+    return new ThumbnailTemplateResponse(summary.thumbnailId(), summary.thumbnailPath());
+  }
+
+  /** `/api/thumbnail-templates` のレスポンス DTO。 */
+  public record ThumbnailTemplateResponse(String thumbnailId, String thumbnailPath) {}
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateQueryServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/thumbnailtemplate/ThumbnailTemplateQueryServiceTest.java
@@ -1,0 +1,66 @@
+package io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplate;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnailtemplate.ThumbnailTemplateRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ThumbnailTemplateQueryServiceTest {
+
+  private final ThumbnailTemplateRepository thumbnailTemplateRepository =
+      Mockito.mock(ThumbnailTemplateRepository.class);
+  private final ThumbnailRepository thumbnailRepository = Mockito.mock(ThumbnailRepository.class);
+
+  private ThumbnailTemplateQueryService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ThumbnailTemplateQueryService(thumbnailTemplateRepository, thumbnailRepository);
+  }
+
+  /** テンプレートに紐づくサムネイルのみが createdAt 降順で返ることを確認する。 */
+  @Test
+  void listTemplatesReturnsOnlyTemplateThumbnailsInOrder() {
+    ThumbnailTemplate newerTemplate =
+        new ThumbnailTemplate("tmpl-2", "thumb-2", Instant.parse("2025-01-02T00:00:00Z"), null);
+    ThumbnailTemplate olderTemplate =
+        new ThumbnailTemplate("tmpl-1", "thumb-1", Instant.parse("2025-01-01T00:00:00Z"), null);
+    when(thumbnailTemplateRepository.findAll()).thenReturn(List.of(olderTemplate, newerTemplate));
+
+    Thumbnail thumb1 = new Thumbnail("thumb-1", "/path/1.png", null, null);
+    Thumbnail thumb2 = new Thumbnail("thumb-2", "/path/2.png", null, null);
+    when(thumbnailRepository.findAllByIds(List.of("thumb-1", "thumb-2")))
+        .thenReturn(List.of(thumb1, thumb2));
+
+    List<ThumbnailTemplateSummary> summaries = service.listTemplates();
+
+    assertThat(summaries).hasSize(2);
+    assertThat(summaries.get(0))
+        .extracting(ThumbnailTemplateSummary::thumbnailId, ThumbnailTemplateSummary::thumbnailPath)
+        .containsExactly("thumb-2", "/path/2.png");
+    assertThat(summaries.get(1))
+        .extracting(ThumbnailTemplateSummary::thumbnailId, ThumbnailTemplateSummary::thumbnailPath)
+        .containsExactly("thumb-1", "/path/1.png");
+  }
+
+  /** テンプレートに紐づくサムネイルが存在しない場合はスキップされることを検証する。 */
+  @Test
+  void listTemplatesSkipsMissingThumbnails() {
+    ThumbnailTemplate template =
+        new ThumbnailTemplate("tmpl-1", "missing-thumb", Instant.now(), null);
+    when(thumbnailTemplateRepository.findAll()).thenReturn(List.of(template));
+    when(thumbnailRepository.findAllByIds(List.of("missing-thumb"))).thenReturn(List.of());
+
+    List<ThumbnailTemplateSummary> summaries = service.listTemplates();
+
+    assertThat(summaries).isEmpty();
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/ThumbnailTemplateControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/ThumbnailTemplateControllerTest.java
@@ -1,0 +1,51 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateQueryService;
+import io.github.tempsotsusei.kotobanotane.application.thumbnailtemplate.ThumbnailTemplateSummary;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/thumbnail-templates` の振る舞いを確認する MockMvc テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ThumbnailTemplateControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private ThumbnailTemplateQueryService thumbnailTemplateQueryService;
+
+  /** JWT 付きの正常系でテンプレートが返ることを検証する。 */
+  @Test
+  void returnsTemplatesWhenAuthenticated() throws Exception {
+    when(thumbnailTemplateQueryService.listTemplates())
+        .thenReturn(
+            List.of(
+                new ThumbnailTemplateSummary("thumb-1", "/path/1.png"),
+                new ThumbnailTemplateSummary("thumb-2", "/path/2.png")));
+
+    mockMvc
+        .perform(get("/api/thumbnail-templates").with(jwt()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].thumbnailId").value("thumb-1"))
+        .andExpect(jsonPath("$[1].thumbnailPath").value("/path/2.png"));
+  }
+
+  /** 未認証リクエストが 401 で拒否されることを確認する。 */
+  @Test
+  void rejectsWhenUnauthenticated() throws Exception {
+    mockMvc.perform(get("/api/thumbnail-templates")).andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
### 概要
/api/thumbnail-templates APIを実装する

### 動作確認
#### Thumbnail Templates API（本番プロファイル）

- `curl -H "Authorization: Bearer <アクセストークン>" http://localhost:${APP_PORT:-8080}/api/thumbnail-templates`
  - テンプレートとして登録されたサムネイルのみが配列で返ることを確認（`thumbnailId`, `thumbnailPath`）。
  - 並び順はテンプレートの `created_at` 降順であることを確認（新しいものが先頭）。
- JWT を省略すると 401 になることを確認

### 関連Issue
close #30 