### PR TITLE
feat:api_/api/story

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"editor.insertSpaces": false,
-	"editor.detectIndentation": false
+	"editor.detectIndentation": false,
+	"java.compile.nullAnalysis.mode": "automatic"
 }

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackGenerationJobService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackGenerationJobService.java
@@ -1,0 +1,76 @@
+package io.github.tempsotsusei.kotobanotane.application.feedback;
+
+import io.github.tempsotsusei.kotobanotane.application.llm.FeedbackGenerationService;
+import io.github.tempsotsusei.kotobanotane.application.llm.FeedbackItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * 章本文を基にフィードバックを生成し、非同期で保存するジョブサービス。
+ *
+ * <p>LLM 呼び出しに失敗した場合は、固定の失敗メッセージを保存して空欄を残さない。
+ */
+@Service
+public class FeedbackGenerationJobService {
+
+  private static final Logger log = LoggerFactory.getLogger(FeedbackGenerationJobService.class);
+  private static final String FAILURE_MESSAGE = "フィードバック生成に失敗しました。";
+  private static final String NO_ISSUE_MESSAGE = "なおすところはなかったよ。";
+
+  private final FeedbackGenerationService feedbackGenerationService;
+  private final FeedbackService feedbackService;
+
+  public FeedbackGenerationJobService(
+      FeedbackGenerationService feedbackGenerationService, FeedbackService feedbackService) {
+    this.feedbackGenerationService = feedbackGenerationService;
+    this.feedbackService = feedbackService;
+  }
+
+  /**
+   * 章本文を平文化した文字列を元にフィードバックを生成し、保存する。
+   *
+   * @param chapterId 保存先の章 ID
+   * @param chapterText 平文化済み章本文
+   */
+  @Async("llmJobExecutor")
+  public void generateAndSave(String chapterId, String chapterText) {
+    try {
+      var feedbacks = feedbackGenerationService.generate(chapterText);
+      String formatted = formatFeedbacks(feedbacks);
+      feedbackService.create(chapterId, formatted);
+      log.info("Feedback generated for chapterId={}", chapterId);
+    } catch (Exception e) {
+      log.warn("Feedback generation failed for chapterId={}", chapterId, e);
+      feedbackService.create(chapterId, FAILURE_MESSAGE);
+    }
+  }
+
+  /**
+   * フィードバック配列を保存用のテキストに整形する。
+   *
+   * @param feedbacks original/corrected/reason のリスト
+   * @return ラベル付きテキスト（間違いなしの場合は固定メッセージ）
+   */
+  private String formatFeedbacks(java.util.List<FeedbackItem> feedbacks) {
+    if (feedbacks == null || feedbacks.isEmpty()) {
+      return NO_ISSUE_MESSAGE;
+    }
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < feedbacks.size(); i++) {
+      FeedbackItem item = feedbacks.get(i);
+      builder
+          .append("［ことばそのまま］\n")
+          .append(item.original())
+          .append("\n［なおしたぶん］\n")
+          .append(item.corrected())
+          .append("\n［どうして？］\n")
+          .append(item.reason());
+      if (i < feedbacks.size() - 1) {
+        builder.append("\n\n");
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/llm/FeedbackGenerationService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/llm/FeedbackGenerationService.java
@@ -1,0 +1,131 @@
+package io.github.tempsotsusei.kotobanotane.application.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.tempsotsusei.kotobanotane.infrastructure.external.openai.OpenAiClient;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 4〜6歳の子どもが書いた文章を、文法だけやさしく直す LLM 呼び出しサービス。
+ *
+ * <p>LLM から構造化されたフィードバック配列を受け取り、original/corrected/reason のリストに変換する。
+ */
+@Service
+public class FeedbackGenerationService {
+
+  private static final String SYSTEM_PROMPT =
+      """
+			あなたは4〜6歳の子どもが書いた文章を、文法だけやさしく直すアシスタントです。
+			内容やストーリーへの意見は不要です。
+			出力はできるだけひらがなで、難しい言葉は使わないでください。
+
+			出力は必ず JSON で返してください。フィールドは `feedbacks` のみで、以下の構造に従ってください:
+			- feedbacks: 配列。間違いの数だけ要素を入れる（上限なし、間違いが無ければ空配列）。
+			- 各要素はオブジェクトで以下を含む:
+			  - original: 修正前の部分文（全文は入れない）
+			  - corrected: 文法だけ直した文（意味は変えない）
+			  - reason: 子どもにもわかるやさしい説明（短く）
+
+			守ること:
+			- 原文を文/行ごとに見て、文法が変なところだけをセット化する。
+			- 1セットにつき1つの直し（全体まとめはしない）。原文の順番どおりに並べる。
+			- 余計なフィールドや文字列化した JSON を返さない。feedbacks 以外は出さない。
+			- 原文は original 以外で書き換えない。意味や内容には触れない。
+			- 文法的に直すところが無い場合は、feedbacks を空配列にする。無理に間違いを作らない。
+
+			出力例:
+			{
+			  "feedbacks": [
+			    {
+			      "original": "わたし、そらのしたで",
+			      "corrected": "わたしはそらのしたで",
+			      "reason": "「わたし」のあとに「は」がなくて、ぶんがつながっていないから。"
+			    },
+			    {
+			      "original": "わたしにへあるいていって、",
+			      "corrected": "わたしのほうへあるいていって、",
+			      "reason": "「にへ」はへんなつながりで、どこにいくのかがわからなくなるから。"
+			    }
+			  ]
+			}
+			""";
+
+  private static final int MAX_OUTPUT_TOKENS = 2000;
+
+  private final OpenAiClient openAiClient;
+  private final ObjectMapper objectMapper;
+
+  public FeedbackGenerationService(OpenAiClient openAiClient, ObjectMapper objectMapper) {
+    this.openAiClient = openAiClient;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * 章本文からフィードバックの配列を生成する。
+   *
+   * @param chapterText 平文化済み章本文
+   * @return original/corrected/reason を含むフィードバックリスト
+   */
+  public List<FeedbackItem> generate(String chapterText) {
+    if (!StringUtils.hasText(chapterText)) {
+      throw new IllegalArgumentException("chapterText must not be blank");
+    }
+
+    JsonNode schema = buildSchema();
+    OpenAiStructuredRequest request =
+        new OpenAiStructuredRequest(
+            SYSTEM_PROMPT, chapterText, schema, "feedbacks_wrapper", MAX_OUTPUT_TOKENS);
+    JsonNode response = openAiClient.requestStructuredJson(request);
+    return parseFeedbacks(response.path("feedbacks"));
+  }
+
+  private List<FeedbackItem> parseFeedbacks(JsonNode feedbacksNode) {
+    if (feedbacksNode == null || !feedbacksNode.isArray()) {
+      return Collections.emptyList();
+    }
+    List<FeedbackItem> items = new ArrayList<>();
+    for (JsonNode node : feedbacksNode) {
+      String original = node.path("original").asText("");
+      String corrected = node.path("corrected").asText("");
+      String reason = node.path("reason").asText("");
+      if (StringUtils.hasText(original)
+          || StringUtils.hasText(corrected)
+          || StringUtils.hasText(reason)) {
+        items.add(new FeedbackItem(original, corrected, reason));
+      }
+    }
+    return items;
+  }
+
+  /** Structured Outputs 用のスキーマを構築する（feedbacks: array of objects）。 */
+  private JsonNode buildSchema() {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("type", "object");
+    ObjectNode properties = objectMapper.createObjectNode();
+
+    ObjectNode feedbacksArray = objectMapper.createObjectNode();
+    feedbacksArray.put("type", "array");
+    ObjectNode feedbackItem = objectMapper.createObjectNode();
+    feedbackItem.put("type", "object");
+    ObjectNode itemProps = objectMapper.createObjectNode();
+    itemProps.putObject("original").put("type", "string");
+    itemProps.putObject("corrected").put("type", "string");
+    itemProps.putObject("reason").put("type", "string");
+    feedbackItem.set("properties", itemProps);
+    feedbackItem.set(
+        "required", objectMapper.createArrayNode().add("original").add("corrected").add("reason"));
+    feedbackItem.put("additionalProperties", false);
+    feedbacksArray.set("items", feedbackItem);
+
+    properties.set("feedbacks", feedbacksArray);
+    root.set("properties", properties);
+    root.set("required", objectMapper.createArrayNode().add("feedbacks"));
+    root.put("additionalProperties", false);
+    return root;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/llm/FeedbackItem.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/llm/FeedbackItem.java
@@ -1,0 +1,4 @@
+package io.github.tempsotsusei.kotobanotane.application.llm;
+
+/** LLM が返す文法修正結果を保持する DTO。 */
+public record FeedbackItem(String original, String corrected, String reason) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/ChapterDraft.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/ChapterDraft.java
@@ -1,0 +1,12 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * 章の登録に必要な入力情報を保持する DTO。
+ *
+ * @param chapterNum 章番号（1 origin）
+ * @param chapterJson TipTap 形式の章本文 JSON
+ * @param plainText 章本文を平文化した文字列（LLM 用／バリデーション用）
+ */
+public record ChapterDraft(int chapterNum, JsonNode chapterJson, String plainText) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/ChapterFeedbackTarget.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/ChapterFeedbackTarget.java
@@ -1,0 +1,9 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+/**
+ * フィードバック生成ジョブに渡す章情報。
+ *
+ * @param chapterId 生成済み章の ID
+ * @param plainText LLM へ渡す平文化済み本文
+ */
+public record ChapterFeedbackTarget(String chapterId, String plainText) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationResult.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationResult.java
@@ -1,0 +1,11 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import java.util.List;
+
+/**
+ * Story と Chapter の登録結果をまとめる DTO。
+ *
+ * @param storyId 登録した Story の ID
+ * @param feedbackTargets フィードバック生成に利用する章情報
+ */
+public record StoryCreationResult(String storyId, List<ChapterFeedbackTarget> feedbackTargets) {}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationService.java
@@ -1,0 +1,121 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterService;
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Story と Chapter を一括作成するアプリケーションサービス。
+ *
+ * <p>バリデーション済みの入力を受け取り、すべての章を登録できない場合はロールバックする。
+ */
+@Service
+public class StoryCreationService {
+
+  private static final int MAX_TITLE_LENGTH = 15;
+  private static final int MAX_CHAPTERS = 5;
+
+  private final StoryRepository storyRepository;
+  private final ChapterService chapterService;
+  private final ThumbnailRepository thumbnailRepository;
+  private final UuidGeneratorService uuidGeneratorService;
+  private final TimeProvider timeProvider;
+
+  public StoryCreationService(
+      StoryRepository storyRepository,
+      ChapterService chapterService,
+      ThumbnailRepository thumbnailRepository,
+      UuidGeneratorService uuidGeneratorService,
+      TimeProvider timeProvider) {
+    this.storyRepository = storyRepository;
+    this.chapterService = chapterService;
+    this.thumbnailRepository = thumbnailRepository;
+    this.uuidGeneratorService = uuidGeneratorService;
+    this.timeProvider = timeProvider;
+  }
+
+  /**
+   * Story と Chapter をトランザクションで一括作成する。
+   *
+   * @param auth0UserId 作成者 Auth0 ID
+   * @param storyTitle タイトル
+   * @param thumbnailId サムネイル ID（任意）
+   * @param drafts バリデーション済みの章入力（平文化テキスト含む）
+   * @return Story ID とフィードバック生成対象の章情報
+   */
+  @Transactional
+  public StoryCreationResult createStoryWithChapters(
+      String auth0UserId, String storyTitle, String thumbnailId, List<ChapterDraft> drafts) {
+    validateTitle(storyTitle);
+    validateChapterCount(drafts);
+
+    String thumbnailToUse = validateThumbnail(thumbnailId);
+    Instant now = timeProvider.nowInstant();
+
+    Story story =
+        new Story(
+            uuidGeneratorService.generateV7(), auth0UserId, storyTitle, thumbnailToUse, now, now);
+    Story savedStory = storyRepository.save(story);
+
+    List<ChapterFeedbackTarget> feedbackTargets = new ArrayList<>();
+    drafts.stream()
+        .sorted(Comparator.comparingInt(ChapterDraft::chapterNum))
+        .forEach(
+            draft -> {
+              Chapter created =
+                  chapterService.create(
+                      savedStory.storyId(), draft.chapterNum(), draft.chapterJson());
+              feedbackTargets.add(
+                  new ChapterFeedbackTarget(created.chapterId(), draft.plainText()));
+            });
+
+    return new StoryCreationResult(savedStory.storyId(), feedbackTargets);
+  }
+
+  /** タイトルが空でなく、最大長を超えないことを検証する。 */
+  private void validateTitle(String storyTitle) {
+    if (!StringUtils.hasText(storyTitle)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "storyTitle must not be blank");
+    }
+    if (storyTitle.length() > MAX_TITLE_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "storyTitle must be 15 characters or less");
+    }
+  }
+
+  /** 章件数が 1〜MAX_CHAPTERS であることを検証する。 */
+  private void validateChapterCount(List<ChapterDraft> drafts) {
+    if (drafts == null || drafts.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapters must not be empty");
+    }
+    if (drafts.size() > MAX_CHAPTERS) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapters must not exceed 5 items");
+    }
+  }
+
+  /** サムネイルが指定されている場合のみ存在チェックを行う。 */
+  private String validateThumbnail(String thumbnailId) {
+    if (!StringUtils.hasText(thumbnailId)) {
+      return null;
+    }
+    boolean exists = thumbnailRepository.findById(thumbnailId).isPresent();
+    if (!exists) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "thumbnailId does not exist: " + thumbnailId);
+    }
+    return thumbnailId;
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryCommandController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryCommandController.java
@@ -1,0 +1,153 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.tempsotsusei.kotobanotane.application.auth.AuthenticatedTokenService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterJsonTextService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterTextAnalysis;
+import io.github.tempsotsusei.kotobanotane.application.feedback.FeedbackGenerationJobService;
+import io.github.tempsotsusei.kotobanotane.application.story.ChapterDraft;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryCreationResult;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryCreationService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 物語と章を一括登録する本番向け API。
+ *
+ * <p>保存完了後、各章について非同期でフィードバック生成ジョブを起動する。
+ */
+@RestController
+@RequestMapping("/api/story")
+public class StoryCommandController {
+
+  private final AuthenticatedTokenService authenticatedTokenService;
+  private final ChapterJsonTextService chapterJsonTextService;
+  private final StoryCreationService storyCreationService;
+  private final FeedbackGenerationJobService feedbackGenerationJobService;
+
+  public StoryCommandController(
+      AuthenticatedTokenService authenticatedTokenService,
+      ChapterJsonTextService chapterJsonTextService,
+      StoryCreationService storyCreationService,
+      FeedbackGenerationJobService feedbackGenerationJobService) {
+    this.authenticatedTokenService = authenticatedTokenService;
+    this.chapterJsonTextService = chapterJsonTextService;
+    this.storyCreationService = storyCreationService;
+    this.feedbackGenerationJobService = feedbackGenerationJobService;
+  }
+
+  /**
+   * 物語と章を登録し、フィードバック生成ジョブを起動する。
+   *
+   * @param request 物語作成リクエスト
+   * @param authentication 認証トークン
+   * @return 作成された storyId
+   */
+  @PostMapping
+  @PreAuthorize("isAuthenticated()")
+  public CreateStoryResponse createStory(
+      @Valid @RequestBody CreateStoryRequest request, JwtAuthenticationToken authentication) {
+    String auth0Id =
+        authenticatedTokenService.requireExistingAuth0Id(
+            authenticatedTokenService.extractAuth0Id(authentication.getToken()));
+    validateChapterNumbers(request.chapters());
+
+    List<ChapterDraft> drafts =
+        request.chapters().stream().map(this::toDraftWithValidation).toList();
+
+    StoryCreationResult result =
+        storyCreationService.createStoryWithChapters(
+            auth0Id, request.storyTitle(), request.thumbnailId(), drafts);
+
+    // 章ごとに非同期でフィードバック生成ジョブを起動する
+    result
+        .feedbackTargets()
+        .forEach(
+            target ->
+                feedbackGenerationJobService.generateAndSave(
+                    target.chapterId(), target.plainText()));
+
+    return new CreateStoryResponse(result.storyId());
+  }
+
+  /**
+   * chapterNum が重複していないか、1 以上かを検証する。
+   *
+   * @param chapters 章リスト
+   */
+  private void validateChapterNumbers(List<ChapterPayload> chapters) {
+    if (chapters == null || chapters.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapters must not be empty");
+    }
+    Set<Integer> numbers = new HashSet<>();
+    for (ChapterPayload chapter : chapters) {
+      if (chapter.chapterNum() == null || chapter.chapterNum() < 1) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "chapterNum must be greater than or equal to 1");
+      }
+      boolean added = numbers.add(chapter.chapterNum());
+      if (!added) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterNum must be unique");
+      }
+    }
+  }
+
+  /**
+   * 章 JSON を解析し、平文化された本文を使ってドラフト DTO を生成する。
+   *
+   * @param chapterPayload リクエスト内の章
+   * @return 章番号・JSON・平文化テキストを含むドラフト
+   */
+  private ChapterDraft toDraftWithValidation(ChapterPayload chapterPayload) {
+    ChapterTextAnalysis analysis = chapterJsonTextService.analyze(chapterPayload.chapterJson());
+    String plainText = analysis.plainText();
+    validatePlainTextLength(plainText);
+    return new ChapterDraft(chapterPayload.chapterNum(), chapterPayload.chapterJson(), plainText);
+  }
+
+  /**
+   * 平文化後の章本文が 1〜200 文字の範囲に収まっているかを検証する。
+   *
+   * @param plainText 平文化後の本文
+   */
+  private void validatePlainTextLength(String plainText) {
+    if (plainText == null || plainText.isBlank()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson text length must be between 1 and 200");
+    }
+    if (plainText.length() > 200) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "chapterJson text length must be between 1 and 200");
+    }
+  }
+
+  /** `/api/story` のリクエスト DTO。 */
+  public record CreateStoryRequest(
+      @JsonProperty("storyTitle") @NotBlank @Size(max = 15) String storyTitle,
+      @JsonProperty("thumbnailId") String thumbnailId,
+      @JsonProperty("chapters") @NotEmpty @Size(min = 1, max = 5)
+          List<@Valid ChapterPayload> chapters) {}
+
+  /** 章のリクエスト要素。 */
+  public record ChapterPayload(
+      @JsonProperty("chapterNum") @NotNull Integer chapterNum,
+      @JsonProperty("chapterJson") @NotNull JsonNode chapterJson) {}
+
+  /** `/api/story` のレスポンス DTO。 */
+  public record CreateStoryResponse(String storyId) {}
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackGenerationJobServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/feedback/FeedbackGenerationJobServiceTest.java
@@ -1,0 +1,55 @@
+package io.github.tempsotsusei.kotobanotane.application.feedback;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.tempsotsusei.kotobanotane.application.llm.FeedbackGenerationService;
+import io.github.tempsotsusei.kotobanotane.application.llm.FeedbackItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class FeedbackGenerationJobServiceTest {
+
+  private final FeedbackGenerationService feedbackGenerationService =
+      Mockito.mock(FeedbackGenerationService.class);
+  private final FeedbackService feedbackService = Mockito.mock(FeedbackService.class);
+
+  private FeedbackGenerationJobService jobService;
+
+  @BeforeEach
+  void setUp() {
+    jobService = new FeedbackGenerationJobService(feedbackGenerationService, feedbackService);
+  }
+
+  /** LLM 成功時に生成されたフィードバックが保存されることを検証する。 */
+  @Test
+  void savesFeedbackWhenLlmSucceeds() {
+    when(feedbackGenerationService.generate("text"))
+        .thenReturn(java.util.List.of(new FeedbackItem("もと", "なおし", "りゆう")));
+
+    jobService.generateAndSave("chap-1", "text");
+
+    verify(feedbackService)
+        .create(
+            "chap-1",
+                """
+						［ことばそのまま］
+						もと
+						［なおしたぶん］
+						なおし
+						［どうして？］
+						りゆう"""
+                .trim());
+  }
+
+  /** LLM 失敗時に固定メッセージが保存されることを検証する。 */
+  @Test
+  void savesFailureMessageWhenLlmFails() {
+    when(feedbackGenerationService.generate("text")).thenThrow(new RuntimeException("llm failure"));
+
+    jobService.generateAndSave("chap-1", "text");
+
+    verify(feedbackService).create("chap-1", "フィードバック生成に失敗しました。");
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationServiceTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/application/story/StoryCreationServiceTest.java
@@ -1,0 +1,116 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterService;
+import io.github.tempsotsusei.kotobanotane.application.uuid.UuidGeneratorService;
+import io.github.tempsotsusei.kotobanotane.config.time.TimeProvider;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.server.ResponseStatusException;
+
+class StoryCreationServiceTest {
+
+  private final StoryRepository storyRepository = Mockito.mock(StoryRepository.class);
+  private final ChapterService chapterService = Mockito.mock(ChapterService.class);
+  private final ThumbnailRepository thumbnailRepository = Mockito.mock(ThumbnailRepository.class);
+  private final UuidGeneratorService uuidGeneratorService =
+      Mockito.mock(UuidGeneratorService.class);
+  private final TimeProvider timeProvider = Mockito.mock(TimeProvider.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private StoryCreationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new StoryCreationService(
+            storyRepository,
+            chapterService,
+            thumbnailRepository,
+            uuidGeneratorService,
+            timeProvider);
+  }
+
+  /** Story と複数章が保存され、フィードバック対象が生成される正常系を検証する。 */
+  @Test
+  void createStoryWithChaptersSavesAllAndReturnsTargets() throws Exception {
+    Instant now = Instant.parse("2025-01-01T00:00:00Z");
+    when(timeProvider.nowInstant()).thenReturn(now);
+    when(uuidGeneratorService.generateV7()).thenReturn("story-1");
+    when(thumbnailRepository.findById("thumb-1"))
+        .thenReturn(
+            java.util.Optional.of(
+                new io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail(
+                    "thumb-1", "/path", now, now)));
+    when(storyRepository.save(Mockito.any(Story.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0, Story.class));
+
+    Chapter chapter1 = new Chapter("chap-1", "story-1", 1, objectMapper.readTree("{}"), now, now);
+    Chapter chapter2 = new Chapter("chap-2", "story-1", 2, objectMapper.readTree("{}"), now, now);
+    when(chapterService.create("story-1", 1, chapter1.chapterJson())).thenReturn(chapter1);
+    when(chapterService.create("story-1", 2, chapter2.chapterJson())).thenReturn(chapter2);
+
+    List<ChapterDraft> drafts =
+        List.of(
+            new ChapterDraft(2, chapter2.chapterJson(), "second"),
+            new ChapterDraft(1, chapter1.chapterJson(), "first"));
+
+    StoryCreationResult result =
+        service.createStoryWithChapters("auth0|user", "物語タイトル", "thumb-1", drafts);
+
+    assertThat(result.storyId()).isEqualTo("story-1");
+    assertThat(result.feedbackTargets()).hasSize(2);
+    assertThat(result.feedbackTargets().get(0).chapterId()).isEqualTo("chap-1");
+    assertThat(result.feedbackTargets().get(1).chapterId()).isEqualTo("chap-2");
+  }
+
+  /** タイトルが16文字以上の場合に 400 となることを検証する。 */
+  @Test
+  void createStoryWithChaptersRejectsTooLongTitle() {
+    List<ChapterDraft> drafts =
+        List.of(new ChapterDraft(1, objectMapper.createObjectNode(), "text"));
+
+    assertThatThrownBy(
+            () -> service.createStoryWithChapters("auth0|user", "abcdefghijklmnop", null, drafts))
+        .isInstanceOf(ResponseStatusException.class);
+  }
+
+  /** 章が 6 件以上の場合に 400 となることを検証する。 */
+  @Test
+  void createStoryWithChaptersRejectsTooManyChapters() {
+    List<ChapterDraft> drafts =
+        List.of(
+            new ChapterDraft(1, objectMapper.createObjectNode(), "a"),
+            new ChapterDraft(2, objectMapper.createObjectNode(), "b"),
+            new ChapterDraft(3, objectMapper.createObjectNode(), "c"),
+            new ChapterDraft(4, objectMapper.createObjectNode(), "d"),
+            new ChapterDraft(5, objectMapper.createObjectNode(), "e"),
+            new ChapterDraft(6, objectMapper.createObjectNode(), "f"));
+
+    assertThatThrownBy(() -> service.createStoryWithChapters("auth0|user", "タイトル", null, drafts))
+        .isInstanceOf(ResponseStatusException.class);
+  }
+
+  /** 存在しないサムネイルを指定した場合に 400 となることを検証する。 */
+  @Test
+  void createStoryWithChaptersRejectsMissingThumbnail() {
+    List<ChapterDraft> drafts =
+        List.of(new ChapterDraft(1, objectMapper.createObjectNode(), "text"));
+    when(thumbnailRepository.findById("missing")).thenReturn(java.util.Optional.empty());
+
+    assertThatThrownBy(
+            () -> service.createStoryWithChapters("auth0|user", "タイトル", "missing", drafts))
+        .isInstanceOf(ResponseStatusException.class);
+  }
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryCommandControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryCommandControllerTest.java
@@ -1,0 +1,185 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.auth.AuthenticatedTokenService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterJsonTextService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterTextAnalysis;
+import io.github.tempsotsusei.kotobanotane.application.feedback.FeedbackGenerationJobService;
+import io.github.tempsotsusei.kotobanotane.application.story.ChapterFeedbackTarget;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryCreationResult;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryCreationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/story` のバリデーションと正常系を確認する MockMvc テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StoryCommandControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private AuthenticatedTokenService authenticatedTokenService;
+  @MockBean private ChapterJsonTextService chapterJsonTextService;
+  @MockBean private StoryCreationService storyCreationService;
+  @MockBean private FeedbackGenerationJobService feedbackGenerationJobService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    when(authenticatedTokenService.extractAuth0Id(any())).thenReturn("auth0|user");
+    when(authenticatedTokenService.requireExistingAuth0Id("auth0|user")).thenReturn("auth0|user");
+  }
+
+  /** JWT 付きの正常系で storyId が返り、フィードバックジョブが章数分起動することを検証する。 */
+  @Test
+  void createsStoryAndStartsFeedbackJobs() throws Exception {
+    when(chapterJsonTextService.analyze(any()))
+        .thenReturn(new ChapterTextAnalysis("短い本文", List.of()));
+    StoryCreationResult result =
+        new StoryCreationResult(
+            "story-1",
+            List.of(
+                new ChapterFeedbackTarget("chap-1", "短い本文"),
+                new ChapterFeedbackTarget("chap-2", "短い本文")));
+    when(storyCreationService.createStoryWithChapters(any(), any(), any(), any()))
+        .thenReturn(result);
+
+    String requestBody =
+        """
+				{
+					"storyTitle": "タイトル",
+					"thumbnailId": "thumb-1",
+					"chapters": [
+						{ "chapterNum": 1, "chapterJson": { "type": "doc" } },
+						{ "chapterNum": 2, "chapterJson": { "type": "doc" } }
+					]
+				}
+				""";
+
+    mockMvc
+        .perform(
+            post("/api/story")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.storyId").value("story-1"));
+
+    verify(feedbackGenerationJobService, times(2)).generateAndSave(any(), any());
+  }
+
+  /** タイトルが16文字以上の場合に 400 となることを検証する。 */
+  @Test
+  void rejectsTooLongTitle() throws Exception {
+    String longTitle = "abcdefghijklmnop";
+    String requestBody =
+            """
+				{
+					"storyTitle": "%s",
+					"thumbnailId": "thumb-1",
+					"chapters": [
+						{ "chapterNum": 1, "chapterJson": { "type": "doc" } }
+					]
+				}
+				"""
+            .formatted(longTitle);
+
+    mockMvc
+        .perform(
+            post("/api/story")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+  }
+
+  /** 章数が 6 以上の場合に 400 となることを検証する。 */
+  @Test
+  void rejectsTooManyChapters() throws Exception {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"storyTitle\":\"タイトル\",\"chapters\":[");
+    for (int i = 1; i <= 6; i++) {
+      sb.append("{\"chapterNum\":").append(i).append(",\"chapterJson\":{\"type\":\"doc\"}},");
+    }
+    sb.append("]}");
+
+    mockMvc
+        .perform(
+            post("/api/story")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(sb.toString()))
+        .andExpect(status().isBadRequest());
+  }
+
+  /** 平文化後 200 文字超の章がある場合に 400 となることを検証する。 */
+  @Test
+  void rejectsTooLongChapterText() throws Exception {
+    String longText = "あ".repeat(201);
+    when(chapterJsonTextService.analyze(any()))
+        .thenReturn(new ChapterTextAnalysis(longText, List.of()));
+
+    String requestBody =
+        """
+				{
+					"storyTitle": "タイトル",
+					"chapters": [
+						{ "chapterNum": 1, "chapterJson": { "type": "doc" } }
+					]
+				}
+				""";
+
+    mockMvc
+        .perform(
+            post("/api/story")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+  }
+
+  /** chapterNum が重複した場合に 400 となることを検証する。 */
+  @Test
+  void rejectsDuplicateChapterNum() throws Exception {
+    when(chapterJsonTextService.analyze(any()))
+        .thenReturn(new ChapterTextAnalysis("短い本文", List.of()));
+
+    String requestBody =
+        """
+				{
+					"storyTitle": "タイトル",
+					"chapters": [
+						{ "chapterNum": 1, "chapterJson": { "type": "doc" } },
+						{ "chapterNum": 1, "chapterJson": { "type": "doc" } }
+					]
+				}
+				""";
+
+    mockMvc
+        .perform(
+            post("/api/story")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
### 概要
/api/story のPOST APIを実装する

### 動作確認
#### Story Create API（本番プロファイル）

- `curl -X POST -H "Authorization: Bearer <アクセストークン>" -H "Content-Type: application/json" -d @story.json http://localhost:${APP_PORT:-8080}/api/story`
  - `story.json` には `storyTitle`（最大15文字）, `thumbnailId`（任意）, `chapters`（1〜5件, chapterNum>=1 重複不可, TipTap `chapterJson`）を含める。
  - 各 `chapterJson` は平文化後 1〜200 文字であることを確認。
- レスポンスは `{"storyId":"..."}`。保存成功後、章ごとに非同期フィードバック生成が走る。
- JWT なしは 401。章数超過やタイトル超過、chapterNum 重複する場合は 400 となる。

### 関連Issue
close #31 