### PR TITLE
feat:api_/api/story?storyId={uuid}

### DIFF
--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryQueryService.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/application/story/StoryQueryService.java
@@ -1,0 +1,153 @@
+package io.github.tempsotsusei.kotobanotane.application.story;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterJsonTextService;
+import io.github.tempsotsusei.kotobanotane.application.chapter.ChapterTextAnalysis;
+import io.github.tempsotsusei.kotobanotane.application.chapter.KeywordPosition;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.FeedbackRepository;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Story 詳細を取得するクエリサービス。
+ *
+ * <p>認証ユーザーと所有者が一致する場合のみフィードバックを返却し、それ以外はフィードバックを非表示にする。
+ */
+@Service
+public class StoryQueryService {
+
+  private final StoryRepository storyRepository;
+  private final ChapterRepository chapterRepository;
+  private final FeedbackRepository feedbackRepository;
+  private final ThumbnailRepository thumbnailRepository;
+  private final ChapterJsonTextService chapterJsonTextService;
+  private final ObjectMapper objectMapper;
+
+  public StoryQueryService(
+      StoryRepository storyRepository,
+      ChapterRepository chapterRepository,
+      FeedbackRepository feedbackRepository,
+      ThumbnailRepository thumbnailRepository,
+      ChapterJsonTextService chapterJsonTextService,
+      ObjectMapper objectMapper) {
+    this.storyRepository = storyRepository;
+    this.chapterRepository = chapterRepository;
+    this.feedbackRepository = feedbackRepository;
+    this.thumbnailRepository = thumbnailRepository;
+    this.chapterJsonTextService = chapterJsonTextService;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Story を取得し、フィードバック表示可否を含めたレスポンス DTO を生成する。
+   *
+   * @param storyId 取得対象 Story ID
+   * @param requesterAuth0Id 認証済みユーザー ID（匿名の場合は null）
+   * @return Story 詳細レスポンス DTO
+   */
+  public StoryDetailResult fetch(String storyId, String requesterAuth0Id) {
+    Story story =
+        storyRepository
+            .findById(storyId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "story not found: " + storyId));
+
+    boolean isOwner = requesterAuth0Id != null && requesterAuth0Id.equals(story.auth0UserId());
+    List<Chapter> chapters = chapterRepository.findAllByStoryIdOrderByChapterNum(story.storyId());
+
+    Map<String, String> feedbackMap =
+        isOwner && !chapters.isEmpty()
+            ? feedbackRepository
+                .findAllByChapterIdIn(chapters.stream().map(Chapter::chapterId).toList())
+                .stream()
+                .collect(Collectors.toMap(Feedback::chapterId, Feedback::feedback))
+            : Collections.emptyMap();
+
+    boolean hasFeedback = isOwner;
+    List<ChapterDetailResult> chapterDetails =
+        chapters.stream()
+            .map(
+                chapter -> {
+                  JsonNode chapterJson = ensureObjectNode(chapter.chapterJson());
+                  ChapterTextAnalysis analysis = chapterJsonTextService.analyze(chapterJson);
+                  List<KeywordItem> keywords =
+                      analysis.keywordsWithOffset().stream()
+                          .map(KeywordPosition::keyword)
+                          .map(KeywordItem::new)
+                          .toList();
+                  String feedback =
+                      isOwner ? feedbackMap.getOrDefault(chapter.chapterId(), "") : null;
+                  return new ChapterDetailResult(
+                      chapter.chapterNum(), chapterJson, keywords, feedback);
+                })
+            .toList();
+
+    String thumbnailPath =
+        Optional.ofNullable(story.thumbnailId())
+            .flatMap(thumbnailRepository::findById)
+            .map(t -> t.thumbnailPath())
+            .orElse(null);
+
+    return new StoryDetailResult(story.storyTitle(), thumbnailPath, hasFeedback, chapterDetails);
+  }
+
+  /**
+   * 文字列ノードで入ってきた場合は JSON にパースし直す。
+   *
+   * @param original Chapter に保存されている JSON ノード
+   * @return ObjectNode 系の JSON
+   */
+  private JsonNode ensureObjectNode(JsonNode original) {
+    if (original == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterJson is missing");
+    }
+    if (original.isTextual()) {
+      try {
+        return objectMapper.readTree(original.asText());
+      } catch (JsonProcessingException e) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chapterJson parse error", e);
+      }
+    }
+    return original;
+  }
+
+  /** Story 詳細レスポンス DTO。 */
+  public record StoryDetailResult(
+      String storyTitle,
+      String thumbnailPath,
+      boolean hasFeedback,
+      List<ChapterDetailResult> chapters) {}
+
+  /** 章のレスポンス DTO。 */
+  public record ChapterDetailResult(
+      int chapterNum,
+      @JsonProperty("chapterJson") JsonNode chapterJson,
+      List<KeywordItem> keywords,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String feedback) {}
+
+  /** キーワード要素。 */
+  public record KeywordItem(String keyword) {
+    public KeywordItem {
+      Objects.requireNonNull(keyword, "keyword must not be null");
+    }
+  }
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/ChapterRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/chapter/ChapterRepository.java
@@ -10,6 +10,9 @@ public interface ChapterRepository {
 
   List<Chapter> findAll();
 
+  /** 指定した Story に紐づく章を章番号順に取得する。 */
+  List<Chapter> findAllByStoryIdOrderByChapterNum(String storyId);
+
   Chapter save(Chapter chapter);
 
   void deleteById(String chapterId);

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/FeedbackRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/domain/feedback/FeedbackRepository.java
@@ -10,6 +10,9 @@ public interface FeedbackRepository {
 
   List<Feedback> findAll();
 
+  /** 章ID一覧に紐づくフィードバックをまとめて取得する。 */
+  List<Feedback> findAllByChapterIdIn(Iterable<String> chapterIds);
+
   Feedback save(Feedback feedback);
 
   void deleteById(String feedbackId);

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterJpaRepository.java
@@ -1,6 +1,10 @@
 package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** chapters テーブルへアクセスする Spring Data JPA リポジトリ。 */
-public interface ChapterJpaRepository extends JpaRepository<ChapterEntity, String> {}
+public interface ChapterJpaRepository extends JpaRepository<ChapterEntity, String> {
+
+  List<ChapterEntity> findAllByStoryIdOrderByChapterNum(String storyId);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/chapter/ChapterRepositoryImpl.java
@@ -29,6 +29,13 @@ public class ChapterRepositoryImpl implements ChapterRepository {
   }
 
   @Override
+  public List<Chapter> findAllByStoryIdOrderByChapterNum(String storyId) {
+    return chapterJpaRepository.findAllByStoryIdOrderByChapterNum(storyId).stream()
+        .map(ChapterMapper::toDomain)
+        .toList();
+  }
+
+  @Override
   @Transactional
   public Chapter save(Chapter chapter) {
     ChapterEntity entity =

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackJpaRepository.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackJpaRepository.java
@@ -1,6 +1,10 @@
 package io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** feedbacks テーブルへアクセスする Spring Data JPA リポジトリ。 */
-public interface FeedbackJpaRepository extends JpaRepository<FeedbackEntity, String> {}
+public interface FeedbackJpaRepository extends JpaRepository<FeedbackEntity, String> {
+
+  List<FeedbackEntity> findAllByChapterIdIn(Iterable<String> chapterIds);
+}

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackRepositoryImpl.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/infrastructure/persistence/feedback/FeedbackRepositoryImpl.java
@@ -29,6 +29,13 @@ public class FeedbackRepositoryImpl implements FeedbackRepository {
   }
 
   @Override
+  public List<Feedback> findAllByChapterIdIn(Iterable<String> chapterIds) {
+    return feedbackJpaRepository.findAllByChapterIdIn(chapterIds).stream()
+        .map(FeedbackMapper::toDomain)
+        .toList();
+  }
+
+  @Override
   @Transactional
   public Feedback save(Feedback feedback) {
     FeedbackEntity entity =

--- a/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryQueryController.java
+++ b/app/src/main/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryQueryController.java
@@ -1,0 +1,83 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.tempsotsusei.kotobanotane.application.auth.AuthenticatedTokenService;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryQueryService;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryQueryService.KeywordItem;
+import io.github.tempsotsusei.kotobanotane.application.story.StoryQueryService.StoryDetailResult;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Story 詳細取得 API。
+ *
+ * <p>認証がなくても参照できるが、認証済みかつ所有者の場合のみフィードバックを含めて返却する。
+ */
+@RestController
+@RequestMapping("/api/story")
+public class StoryQueryController {
+
+  private final AuthenticatedTokenService authenticatedTokenService;
+  private final StoryQueryService storyQueryService;
+
+  public StoryQueryController(
+      AuthenticatedTokenService authenticatedTokenService, StoryQueryService storyQueryService) {
+    this.authenticatedTokenService = authenticatedTokenService;
+    this.storyQueryService = storyQueryService;
+  }
+
+  /**
+   * Story を取得する。認証済みかつ所有者であればフィードバックも返却する。
+   *
+   * @param storyId 取得対象 Story ID
+   * @param authentication 任意の JWT（匿名の場合は null）
+   * @return Story 詳細レスポンス
+   */
+  @GetMapping
+  @PreAuthorize("permitAll()")
+  public StoryResponse getStory(
+      @RequestParam("storyId") String storyId, JwtAuthenticationToken authentication) {
+    String auth0Id = null;
+    if (authentication != null) {
+      auth0Id =
+          authenticatedTokenService.requireExistingAuth0Id(
+              authenticatedTokenService.extractAuth0Id(authentication.getToken()));
+    }
+
+    StoryDetailResult detail = storyQueryService.fetch(storyId, auth0Id);
+    List<ChapterResponse> chapters =
+        detail.chapters().stream()
+            .map(
+                chapter ->
+                    new ChapterResponse(
+                        chapter.chapterNum(),
+                        chapter.chapterJson(),
+                        chapter.keywords(),
+                        chapter.feedback()))
+            .toList();
+
+    return new StoryResponse(
+        detail.storyTitle(), detail.thumbnailPath(), detail.hasFeedback(), chapters);
+  }
+
+  /** `/api/story` のレスポンス DTO。 */
+  public record StoryResponse(
+      String storyTitle,
+      String thumbnailPath,
+      boolean hasFeedback,
+      List<ChapterResponse> chapters) {}
+
+  /** 章のレスポンス DTO。 */
+  public record ChapterResponse(
+      int chapterNum,
+      @JsonProperty("chapterJson") JsonNode chapterJson,
+      List<KeywordItem> keywords,
+      @JsonInclude(JsonInclude.Include.NON_NULL) String feedback) {}
+}

--- a/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryQueryControllerTest.java
+++ b/app/src/test/java/io/github/tempsotsusei/kotobanotane/interfaces/api/StoryQueryControllerTest.java
@@ -1,0 +1,178 @@
+package io.github.tempsotsusei.kotobanotane.interfaces.api;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.Chapter;
+import io.github.tempsotsusei.kotobanotane.domain.chapter.ChapterRepository;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.Feedback;
+import io.github.tempsotsusei.kotobanotane.domain.feedback.FeedbackRepository;
+import io.github.tempsotsusei.kotobanotane.domain.story.Story;
+import io.github.tempsotsusei.kotobanotane.domain.story.StoryRepository;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.Thumbnail;
+import io.github.tempsotsusei.kotobanotane.domain.thumbnail.ThumbnailRepository;
+import io.github.tempsotsusei.kotobanotane.domain.user.User;
+import io.github.tempsotsusei.kotobanotane.domain.user.UserRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.chapter.ChapterJpaRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.feedback.FeedbackJpaRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.story.StoryJpaRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.thumbnail.ThumbnailJpaRepository;
+import io.github.tempsotsusei.kotobanotane.infrastructure.persistence.user.UserJpaRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** `/api/story?storyId=...` の取得を検証する MockMvc テスト。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StoryQueryControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private StoryRepository storyRepository;
+  @Autowired private ChapterRepository chapterRepository;
+  @Autowired private FeedbackRepository feedbackRepository;
+  @Autowired private ThumbnailRepository thumbnailRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private StoryJpaRepository storyJpaRepository;
+  @Autowired private ChapterJpaRepository chapterJpaRepository;
+  @Autowired private FeedbackJpaRepository feedbackJpaRepository;
+  @Autowired private ThumbnailJpaRepository thumbnailJpaRepository;
+  @Autowired private UserJpaRepository userJpaRepository;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    feedbackJpaRepository.deleteAll();
+    chapterJpaRepository.deleteAll();
+    storyJpaRepository.deleteAll();
+    thumbnailJpaRepository.deleteAll();
+    userJpaRepository.deleteAll();
+  }
+
+  /** 所有者 JWT の場合に hasFeedback=true でフィードバックが返ることを確認する。 */
+  @Test
+  void returnsFeedbackForOwner() throws Exception {
+    Instant now = Instant.parse("2025-01-01T00:00:00Z");
+    userRepository.save(new User("auth0|owner", now, now));
+    thumbnailRepository.save(new Thumbnail("thumb-1", "/path/thumb.png", now, now));
+    storyRepository.save(new Story("story-1", "auth0|owner", "タイトル", "thumb-1", now, now));
+
+    JsonNode chapterJson =
+        objectMapper.readTree(
+            """
+            {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "customWord", "attrs": { "text": "船" } },
+                    { "type": "text", "text": "が" },
+                    { "type": "customWord", "attrs": { "text": "静寂" } }
+                  ]
+                }
+              ]
+            }
+            """);
+    chapterRepository.save(new Chapter("chap-1", "story-1", 1, chapterJson, now, now));
+    chapterRepository.save(new Chapter("chap-2", "story-1", 2, chapterJson, now, now));
+    feedbackRepository.save(new Feedback("fb-1", "chap-1", "感想A", now, now));
+
+    mockMvc
+        .perform(
+            get("/api/story")
+                .param("storyId", "story-1")
+                .with(jwt().jwt(jwt -> jwt.subject("auth0|owner"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasFeedback").value(true))
+        .andExpect(jsonPath("$.thumbnailPath").value("/path/thumb.png"))
+        .andExpect(jsonPath("$.chapters[0].feedback").value("感想A"))
+        .andExpect(jsonPath("$.chapters[1].feedback").value(""));
+  }
+
+  /** 非所有者 JWT の場合にフィードバックが非表示になることを確認する。 */
+  @Test
+  void hidesFeedbackForNonOwner() throws Exception {
+    Instant now = Instant.parse("2025-01-02T00:00:00Z");
+    storyRepository.save(new Story("story-2", "auth0|owner", "タイトル", null, now, now));
+    userRepository.save(new User("auth0|owner", now, now));
+    userRepository.save(new User("auth0|other", now, now));
+    JsonNode chapterJson =
+        objectMapper.readTree(
+            """
+            {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "customWord", "attrs": { "text": "静寂" } },
+                    { "type": "text", "text": "の" },
+                    { "type": "customWord", "attrs": { "text": "船" } }
+                  ]
+                }
+              ]
+            }
+            """);
+    chapterRepository.save(new Chapter("chap-3", "story-2", 1, chapterJson, now, now));
+    feedbackRepository.save(new Feedback("fb-3", "chap-3", "感想B", now, now));
+
+    mockMvc
+        .perform(
+            get("/api/story")
+                .param("storyId", "story-2")
+                .with(jwt().jwt(jwt -> jwt.subject("auth0|other"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasFeedback").value(false))
+        .andExpect(jsonPath("$.chapters[0].feedback").doesNotExist());
+  }
+
+  /** 匿名アクセスの場合にフィードバックが非表示になることを確認する。 */
+  @Test
+  void hidesFeedbackForAnonymous() throws Exception {
+    Instant now = Instant.parse("2025-01-03T00:00:00Z");
+    storyRepository.save(new Story("story-3", "auth0|owner", "タイトル", null, now, now));
+    userRepository.save(new User("auth0|owner", now, now));
+    JsonNode chapterJson =
+        objectMapper.readTree(
+            """
+            {
+              "type": "doc",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "content": [
+                    { "type": "customWord", "attrs": { "text": "鼓動" } }
+                  ]
+                }
+              ]
+            }
+            """);
+    chapterRepository.save(new Chapter("chap-4", "story-3", 1, chapterJson, now, now));
+
+    mockMvc
+        .perform(
+            get("/api/story").param("storyId", "story-3").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasFeedback").value(false))
+        .andExpect(jsonPath("$.chapters[0].feedback").doesNotExist());
+  }
+
+  /** 存在しない storyId の場合に 404 となることを確認する。 */
+  @Test
+  void returnsNotFoundWhenStoryMissing() throws Exception {
+    mockMvc.perform(get("/api/story").param("storyId", "missing")).andExpect(status().isNotFound());
+  }
+}


### PR DESCRIPTION
### 概要
/api/story のGET APIを実装する

### 動作確認
#### Story Get API（本番プロファイル）

- `curl -H "Authorization: Bearer <アクセストークン>" "http://localhost:${APP_PORT:-8080}/api/story?storyId=<storyId>"`
  - JWT なしでも取得可（匿名）。JWT があり、かつ所有者ならフィードバックも返る。
  - 所有者: `hasFeedback=true`。フィードバック未到着の章は `feedback=""`。TipTap JSON から抽出した keywords を返す（position なし）。
  - 非所有者/匿名: `hasFeedback=false`。`feedback` は返さない（項目ごと省略）。keywords は抽出したものを返す（position なし）。
  - 壊れた JWT は 401、存在しない storyId は 404 になることを確認。

### 関連Issue
close #32 